### PR TITLE
Pin the versions in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 pytest>=3.0.0
-pytest-asyncio
-pytest-aiohttp
+pytest-asyncio==0.5.0
+pytest-aiohttp==0.1.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-pytest==3.0.7
-pytest-asyncio==0.5.0
-pytest-aiohttp==0.1.3
+pytest~=3.0.7
+pytest-asyncio~=0.5.0
+pytest-aiohttp~=0.1.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-pytest>=3.0.0
+pytest==3.0.7
 pytest-asyncio==0.5.0
 pytest-aiohttp==0.1.3


### PR DESCRIPTION
Set `pytest-aiohttp` to v 0.1.3 
Set `pytest-asyncio` to v 0.5.0
Set `pytest` to v 3.0.7

I tried running the tests locally last night and they failed due to recent updates in pytest-asyncio.

The tests passed again after setting `pytest-asyncio` to version 0.5.0
Per @brettcannon's suggestion, also set the version of `pytest-aiohttp`.

Edit: A lot of warnings were generated when using `pytest` 3.1.0. ([travis log](https://travis-ci.org/python/bedevere/builds/237239682)) Setting it the version to 3.0.7