### PR TITLE
set the "maintainer_can_modify" flag to True in bpo.py

### DIFF
--- a/bedevere/bpo.py
+++ b/bedevere/bpo.py
@@ -51,7 +51,9 @@ async def set_status(event, gh, *args, **kwargs):
             if CLOSING_TAG not in body:
                 issue_number = issue_number_found.group("issue")
                 new_body = BODY.format(body=body, issue_number=issue_number)
-                body_data = {"body": new_body}
+                body_data = {"body": new_body,
+                             "maintainer_can_modify": True
+                            }
                 await gh.patch(event.data["pull_request"]["url"], data=body_data)
         status = create_success_status(issue_number_found)
     await _post_status(event, gh, status)


### PR DESCRIPTION
When bedevere updates the PR body, also pass in the `"maintainer_can_modify"` flag.

I'm wondering if it gets set to `False` when the flag is not set, which is causing recent PRs in CPython repo to not be editable by maintainers. Just a guess. Maybe a better approach is to first check what the flag was set to before updating the PR. 
