### PR TITLE
Remove backport label when PR is edited.

### DIFF
--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -16,6 +16,7 @@ MESSAGE_TEMPLATE = ('[GH-{pr}](https://github.com/python/cpython/pull/{pr}) is '
 
 
 @router.register("pull_request", action="opened")
+@router.register("pull_request", action="edited")
 async def remove_backport_label(event, gh, *args, **kwargs):
     title = util.normalize_title(event.data['pull_request']['title'],
                                  event.data['pull_request']['body'])


### PR DESCRIPTION
Sometimes when creating the backport PR, the [X.Y] prefix was not added.
If the title is edited afterwards, bedevere should then remove the backport label.
 
Fixes https://github.com/python/bedevere/issues/50