### PR TITLE
Close PR that tries to merge maintenance branch into master

### DIFF
--- a/bedevere/__main__.py
+++ b/bedevere/__main__.py
@@ -11,11 +11,11 @@ from gidgethub import aiohttp as gh_aiohttp
 from gidgethub import routing
 from gidgethub import sansio
 
-from . import backport, bpo, news, stage, close_pr
+from . import backport, bpo, close_pr, news, stage
 
 
-router = routing.Router(backport.router, bpo.router, news.router, stage.router,
-                        close_pr.router)
+router = routing.Router(backport.router, bpo.router, close_pr.router,
+                        news.router, stage.router)
 cache = cachetools.LRUCache(maxsize=500)
 
 

--- a/bedevere/__main__.py
+++ b/bedevere/__main__.py
@@ -11,10 +11,11 @@ from gidgethub import aiohttp as gh_aiohttp
 from gidgethub import routing
 from gidgethub import sansio
 
-from . import backport, bpo, news, stage
+from . import backport, bpo, news, stage, close_pr
 
 
-router = routing.Router(backport.router, bpo.router, news.router, stage.router)
+router = routing.Router(backport.router, bpo.router, news.router, stage.router,
+                        close_pr.router)
 cache = cachetools.LRUCache(maxsize=500)
 
 

--- a/bedevere/close_pr.py
+++ b/bedevere/close_pr.py
@@ -12,9 +12,10 @@ router = gidgethub.routing.Router()
 @router.register("pull_request", action="synchronize")
 async def close_invalid_pr(event, gh, *args, **kwargs):
     """Close the invalid PR.
+
     PR is considered invalid if:
-    base_label is 'python:master', and
-    head_label is 'python:<maint_branch>'
+    * base_label is 'python:master'
+    * head_label is 'python:<maint_branch>'
     """
     head_label = event.data["pull_request"]["head"]["label"]
     base_label = event.data["pull_request"]["base"]["label"]

--- a/bedevere/close_pr.py
+++ b/bedevere/close_pr.py
@@ -1,0 +1,28 @@
+"""Automatically close PR that tries to merge maintenance branch into master"""
+import re
+
+import gidgethub.routing
+
+PYTHON_MAINT_BRANCH_RE = re.compile(r'^python:\d+.\d+$')
+
+router = gidgethub.routing.Router()
+
+@router.register("pull_request", action="opened")
+@router.register("pull_request", action="synchronize")
+async def close_invalid_pr(event, gh, *args, **kwargs):
+    """
+    Close the invalid PR
+    PR is considered invalid if:
+    base_label is 'python:master', and
+    head_label is 'python:<maint_branch>'
+    """
+    head_label = event["pull_request"]["head"]["label"]
+    base_label = event["pull_request"]["base"]["label"]
+
+    if PYTHON_MAINT_BRANCH_RE.match(head_label) and \
+        base_label == "python:master":
+        data = {'state': 'closed',
+                'maintainer_can_modify': True
+                }
+        await gh.patch(event.data["pull_request"]["url"], data=data)
+

--- a/bedevere/close_pr.py
+++ b/bedevere/close_pr.py
@@ -1,7 +1,8 @@
-"""Automatically close PR that tries to merge maintenance branch into master"""
+"""Automatically close PR that tries to merge maintenance branch into master."""
 import re
 
 import gidgethub.routing
+
 
 PYTHON_MAINT_BRANCH_RE = re.compile(r'^python:\d+.\d+$')
 
@@ -10,19 +11,17 @@ router = gidgethub.routing.Router()
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="synchronize")
 async def close_invalid_pr(event, gh, *args, **kwargs):
-    """
-    Close the invalid PR
+    """Close the invalid PR.
     PR is considered invalid if:
     base_label is 'python:master', and
     head_label is 'python:<maint_branch>'
     """
-    head_label = event["pull_request"]["head"]["label"]
-    base_label = event["pull_request"]["base"]["label"]
+    head_label = event.data["pull_request"]["head"]["label"]
+    base_label = event.data["pull_request"]["base"]["label"]
 
     if PYTHON_MAINT_BRANCH_RE.match(head_label) and \
         base_label == "python:master":
         data = {'state': 'closed',
-                'maintainer_can_modify': True
-                }
+                'maintainer_can_modify': True}
         await gh.patch(event.data["pull_request"]["url"], data=data)
 

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -21,6 +21,7 @@ class FakeGH:
 @pytest.mark.asyncio
 async def test_close_invalid_pr():
     data = {
+        "action": "opened",
         "pull_request": {
             "statuses_url": "https://api.github.com/blah/blah/git-sha",
             "title": "No issue in title",
@@ -41,7 +42,7 @@ async def test_close_invalid_pr():
     }
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     gh = FakeGH(getitem=pr_data)
-    await close_pr.close_invalid_pr(event, gh)
+    await close_pr.router.dispatch(event, gh)
     patch_data = gh.patch_data
     assert patch_data["state"] == "closed"
 
@@ -69,6 +70,6 @@ async def test_valid_pr_not_closed():
     }
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     gh = FakeGH(getitem=pr_data)
-    await close_pr.close_invalid_pr(event, gh)
+    await close_pr.router.dispatch(event, gh)
     patch_data = gh.patch_data
     assert patch_data is None

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -79,6 +79,7 @@ async def test_close_invalid_pr_on_synchronize():
 @pytest.mark.asyncio
 async def test_valid_pr_not_closed():
     data = {
+        "action": "opened",
         "pull_request": {
             "statuses_url": "https://api.github.com/blah/blah/git-sha",
             "title": "No issue in title",

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -13,13 +13,6 @@ class FakeGH:
         self.patch_data = None
         self.data = None
 
-    async def getitem(self, url):
-        return self._getitem_return
-
-    async def post(self, url, data):
-        self.url = url
-        self.data = data
-
     async def patch(self, url, data):
         self.patch_url = url
         self.patch_data = data

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -48,7 +48,7 @@ async def test_close_invalid_pr_on_open():
 
 
 @pytest.mark.asyncio
-async def test_close_invalid_pr_on_open():
+async def test_close_invalid_pr_on_synchronize():
     data = {
         "action": "synchronize",
         "pull_request": {

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -19,9 +19,38 @@ class FakeGH:
 
 
 @pytest.mark.asyncio
-async def test_close_invalid_pr():
+async def test_close_invalid_pr_on_open():
     data = {
         "action": "opened",
+        "pull_request": {
+            "statuses_url": "https://api.github.com/blah/blah/git-sha",
+            "title": "No issue in title",
+            "issue_url": "issue URL",
+            "url": "https://api.github.com/org/repo/pulls/123",
+            "head": {
+                "label": "python:3.6"
+            },
+            "base": {
+                "label": "python:master"
+            }
+        },
+    }
+    pr_data = {
+        "labels": [
+            {"name": "non-trivial"},
+        ]
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="12345")
+    gh = FakeGH(getitem=pr_data)
+    await close_pr.router.dispatch(event, gh)
+    patch_data = gh.patch_data
+    assert patch_data["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_close_invalid_pr_on_open():
+    data = {
+        "action": "synchronize",
         "pull_request": {
             "statuses_url": "https://api.github.com/blah/blah/git-sha",
             "title": "No issue in title",

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -1,0 +1,81 @@
+import pytest
+
+from gidgethub import sansio
+
+from bedevere import close_pr
+
+
+class FakeGH:
+
+    def __init__(self, *, getitem=None):
+        self._getitem_return = getitem
+        self.patch_url = None
+        self.patch_data = None
+        self.data = None
+
+    async def getitem(self, url):
+        return self._getitem_return
+
+    async def post(self, url, data):
+        self.url = url
+        self.data = data
+
+    async def patch(self, url, data):
+        self.patch_url = url
+        self.patch_data = data
+
+
+@pytest.mark.asyncio
+async def test_close_invalid_pr():
+    data = {
+        "pull_request": {
+            "statuses_url": "https://api.github.com/blah/blah/git-sha",
+            "title": "No issue in title",
+            "issue_url": "issue URL",
+            "url": "https://api.github.com/org/repo/pulls/123",
+            "head": {
+                "label": "python:3.6"
+            },
+            "base": {
+                "label": "python:master"
+            }
+        },
+    }
+    pr_data = {
+        "labels": [
+            {"name": "non-trivial"},
+        ]
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="12345")
+    gh = FakeGH(getitem=pr_data)
+    await close_pr.close_invalid_pr(event, gh)
+    patch_data = gh.patch_data
+    assert patch_data["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_valid_pr_not_closed():
+    data = {
+        "pull_request": {
+            "statuses_url": "https://api.github.com/blah/blah/git-sha",
+            "title": "No issue in title",
+            "issue_url": "issue URL",
+            "url": "https://api.github.com/org/repo/pulls/123",
+            "head": {
+                "label": "someuser:bpo-3.6"
+            },
+            "base": {
+                "label": "python:master"
+            }
+        },
+    }
+    pr_data = {
+        "labels": [
+            {"name": "non-trivial"},
+        ]
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="12345")
+    gh = FakeGH(getitem=pr_data)
+    await close_pr.close_invalid_pr(event, gh)
+    patch_data = gh.patch_data
+    assert patch_data is None


### PR DESCRIPTION
This will close invalid PRs, so at least one less boring chore for core devs.
People in codeowners still get notified though...

A PR is considered invalid if it tries to merge `python:<maint_branch>` into `python:master`.
For example `python:3.6` into `python:master`.

Closes https://github.com/python/core-workflow/issues/168