### PR TITLE
 Periodic job to label stale PRs python/core-workflow#93

### DIFF
--- a/bedevere/stale_pr.py
+++ b/bedevere/stale_pr.py
@@ -1,0 +1,43 @@
+"""Add stale label to pull requests with label CLA not signed/awaiting changes and no activity."""
+import os
+from datetime import datetime
+import asyncio
+import aiohttp
+from gidgethub import aiohttp as gh_aiohttp
+
+
+from . import util
+
+STALE_LABEL = 'stale'
+PR_ACTIVE_DURATION = 30 #days
+
+def is_pr(issue):
+    return issue.get('pull_request') != None
+
+def is_stale(issue):
+    updated_at = datetime.strptime(issue['updated_at'], '%Y-%m-%dT%H:%M:%SZ')
+    return (datetime.now() - updated_at).days > PR_ACTIVE_DURATION
+
+def has_stale_label(issue):
+    return STALE_LABEL in util.labels(issue) 
+
+async def process_issue(issue, gh):
+    if is_pr(issue) and is_stale(issue) and not has_stale_label(issue):
+        print("Adding stale label to issue " + str(issue['number']))
+        await gh.post(issue['labels_url'], data=[STALE_LABEL])
+
+async def label_stale_prs(gh):
+    async for issue in gh.getiter("/repos/python/cpython/issues?labels=CLA%20not%20signed&sort=updated&direction=asc&state=open"):
+        await process_issue(issue, gh)
+
+    async for issue in gh.getiter("/repos/python/cpython/issues?labels=awaiting%20changes&sort=updated&direction=asc&state=open"):
+        await process_issue(issue, gh)
+
+
+async def invoke():
+    oauth_token = os.environ.get("GH_AUTH")
+    async with aiohttp.ClientSession() as session:
+        gh = gh_aiohttp.GitHubAPI(session, "python/bedevere", oauth_token=oauth_token)
+        # Give GitHub some time to reach internal consistency.
+        await asyncio.sleep(1)
+        return await label_stale_prs(gh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==2.1.0
 appdirs==1.4.3
+APScheduler==3.3.1
 async-timeout==1.2.1
 cachetools==2.0.0
 chardet==3.0.4
@@ -8,6 +9,8 @@ multidict==2.1.6
 packaging==16.8
 py==1.4.33
 pyparsing==2.2.0
+pytz==2017.2
 six==1.10.0
+tzlocal==1.4
 uritemplate==3.0.0
 yarl==0.10.3

--- a/tests/test_stale_pr.py
+++ b/tests/test_stale_pr.py
@@ -1,0 +1,104 @@
+import pytest
+from datetime import datetime
+from gidgethub import sansio
+
+from bedevere import stale_pr
+
+
+class FakeGH:
+
+    async def getiter(self, url):
+        for issue in self._issues:
+            yield issue
+
+    def __init__(self, *, issues, getitem=None):
+        self.post_url = None
+        self.post_data = None
+        self._issues = issues
+
+    async def post(self, url, data):
+        self.post_url = url
+        self.post_data = data
+
+
+@pytest.mark.asyncio
+async def test_stale_pr_labelled_stale():
+    issue = {
+        "labels_url": "https://api.github.com/repos/python/cpython/issues/3919/labels{/name}",
+        "id": 263653898,
+        "number": 3919,
+        "labels": [{
+            "name": "awaiting review"
+        },
+        {
+            "name": "CLA signed"
+        }
+        ],
+        "state": "open",
+        "created_at": "2017-08-07T16:34:58Z",
+        "updated_at": "2017-08-07T16:35:01Z",
+        "pull_request": {
+            "url": "https://api.github.com/repos/python/cpython/pulls/3919"
+        }
+    }
+    gh = FakeGH(issues=[issue])
+    await stale_pr.label_stale_prs(gh)
+    assert gh.post_data == ["stale"]
+
+
+@pytest.mark.asyncio
+async def test_no_action_on_labelled_stale_pr():
+    issue = {
+        "labels_url": "https://api.github.com/repos/python/cpython/issues/3919/labels{/name}",
+        "id": 263653898,
+        "number": 3919,
+        "labels": [{
+            "name": "awaiting review"
+        },
+        {
+            "name": "stale"
+        }
+        ],
+        "state": "open",
+        "created_at": "2017-10-07T16:34:58Z",
+        "updated_at": "2017-10-07T16:35:01Z",
+        "pull_request": {
+            "url": "https://api.github.com/repos/python/cpython/pulls/3919"
+        }
+    }
+    gh = FakeGH(issues=[issue])
+    await stale_pr.label_stale_prs(gh)
+    assert gh.post_data == None
+
+@pytest.mark.asyncio
+async def test_no_action_on_active_pr():
+    updated_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    issue = {
+        "labels_url": "https://api.github.com/repos/python/cpython/issues/3919/labels{/name}",
+        "id": 263653898,
+        "number": 3919,
+        "labels": [{
+            "name": "awaiting review"
+        },
+        {
+            "name": "CLA signed"
+        }
+        ],
+        "state": "open",
+        "created_at": "2016-10-07T16:34:58Z",
+        "updated_at": updated_at,
+        "pull_request": {
+            "url": "https://api.github.com/repos/python/cpython/pulls/3919"
+        }
+    }
+    gh = FakeGH(issues=[issue])
+    await stale_pr.label_stale_prs(gh)
+    assert gh.post_data == None
+
+@pytest.mark.asyncio
+async def test_invoke():
+    async def stub(self):
+        return "done"
+    stale_pr.label_stale_prs = stub
+    result = await stale_pr.invoke() 
+    assert result == "done"


### PR DESCRIPTION
This pr adds a periodic job to detect and label stale pull requests.

A pull request is considered stale if it was not updated in last 30 days and it has labels 
CLA not signed/ awaiting changes.

The job will run daily at 12am and will mark pull request stale only if required.
The job is scheduled using https://github.com/agronholm/apscheduler.
Apscheduler is a pure python library and doesn't depend on any external cron/task queue for triggering the task. This helps in making the bot cross platform.
