### PR TITLE
pull_request_review state should be `commented` instead of `comment`.

### DIFF
--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -156,7 +156,7 @@ async def new_review(event, gh, *args, **kwargs):
     review = event.data["review"]
     reviewer = util.user_login(review)
     state = review["state"].lower()
-    if state == "comment":
+    if state == "commented":
         # Don't care about comment reviews.
         return
     elif not await util.is_core_dev(gh, reviewer):

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -155,7 +155,7 @@ async def test_new_review():
     iterators = {
         "https://api.github.com/orgs/python/teams": teams,
         "https://api.github.com/pr/42/reviews":
-            [{"user": {"login": "brettcannon"}, "state": "comment"}],
+            [{"user": {"login": "brettcannon"}, "state": "commented"}],
     }
     gh = FakeGH(getiter=iterators, getitem=items)
     await awaiting.router.dispatch(event, gh)
@@ -293,7 +293,7 @@ async def test_new_review():
             "user": {
                 "login": username,
             },
-            "state": "comment".upper(),
+            "state": "commented".upper(),
         },
         "pull_request": {
             "url": "https://api.github.com/pr/42",


### PR DESCRIPTION
I noticed a few failed webhook deliveries, with delivery IDs:
e803a5f0-b3c2-11e7-88b0-b656aa65ce54
726f2a80-b390-11e7-9de2-d0a4e98e7a9f

In the payload from GitHub, it shows that `["review"]["state"]` is `"commented"`, but bedevere was expecting `"comment"`. I think that was the problem.


