### PR TITLE
Only close invalid PRs that match Python maintenance branch patterns.

### DIFF
--- a/bedevere/close_pr.py
+++ b/bedevere/close_pr.py
@@ -4,7 +4,7 @@ import re
 import gidgethub.routing
 
 
-PYTHON_MAINT_BRANCH_RE = re.compile(r'^\w+:\d+.\d+$')
+PYTHON_MAINT_BRANCH_RE = re.compile(r'^\w+:\d+\.\d+$')
 
 router = gidgethub.routing.Router()
 

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -132,3 +132,32 @@ async def test_close_invalid_pr_on_open_not_python_as_head():
     await close_pr.router.dispatch(event, gh)
     patch_data = gh.patch_data
     assert patch_data["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_pr_with_head_branch_containing_all_digits_not_closed():
+    data = {
+        "action": "opened",
+        "pull_request": {
+            "statuses_url": "https://api.github.com/blah/blah/git-sha",
+            "title": "No issue in title",
+            "issue_url": "issue URL",
+            "url": "https://api.github.com/org/repo/pulls/123",
+            "head": {
+                "label": "someuser:12345"
+            },
+            "base": {
+                "label": "python:master"
+            }
+        },
+    }
+    pr_data = {
+        "labels": [
+            {"name": "non-trivial"},
+        ]
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="12345")
+    gh = FakeGH(getitem=pr_data)
+    await close_pr.router.dispatch(event, gh)
+    patch_data = gh.patch_data
+    assert patch_data is None


### PR DESCRIPTION
The regex pattern wasn't correct.
It was matching on head branch that contains only digits (e.g. 12345).