### PR TITLE
Make the "Change requested" message brief when PR is authored by Core Dev

### DIFF
--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -70,6 +70,14 @@ you're ready for them to take another look at this pull request.
 {{easter_egg}}
 """
 
+CORE_DEV_CHANGES_REQUESTED_MESSAGE = f"""\
+<!-- {TAG_NAME} -->
+When you're done making the requested changes, say: `{BORING_TRIGGER_PHRASE}`.
+<!-- /{TAG_NAME} -->
+
+{{easter_egg}}
+"""
+
 EASTER_EGG_1 = """\
 And if you don't make the requested changes, \
 [you will be poked with soft cushions!](https://www.youtube.com/watch?v=Nf_Y4MbUCLY&feature=youtu.be&t=4m7s)
@@ -181,6 +189,10 @@ async def new_review(event, gh, *args, **kwargs):
             if random.random() < 0.1:  # pragma: no cover
                 easter_egg = random.choice([EASTER_EGG_1, EASTER_EGG_2])
             comment = CHANGES_REQUESTED_MESSAGE.format(easter_egg=easter_egg)
+            pr_author = util.user_login(pull_request)
+            if await util.is_core_dev(gh, pr_author):
+                comment = CORE_DEV_CHANGES_REQUESTED_MESSAGE.format(
+                    easter_egg=easter_egg)
             await stage(gh, issue, Blocker.changes)
             await gh.post(pull_request["comments_url"], data={"body": comment})
         else: # pragma: no cover

--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -72,7 +72,7 @@ you're ready for them to take another look at this pull request.
 
 CORE_DEV_CHANGES_REQUESTED_MESSAGE = f"""\
 <!-- {TAG_NAME} -->
-When you're done making the requested changes, say: `{BORING_TRIGGER_PHRASE}`.
+When you're done making the requested changes, leave the comment: `{BORING_TRIGGER_PHRASE}`.
 <!-- /{TAG_NAME} -->
 
 {{easter_egg}}

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -266,11 +266,15 @@ async def test_new_review():
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
+            "user": {
+                "login": "miss-islington"
+            }
         },
     }
     event = sansio.Event(data, event="pull_request_review", delivery_id="12345")
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
+        f"https://api.github.com/teams/6/memberships/miss-islington": False,
         "https://api.github.com/issue/42": {
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
@@ -436,6 +440,56 @@ async def test_new_comment():
     assert "@brettcannon" in comment_body
     assert "@gvanrossum" in comment_body
     assert "not-core-dev" not in comment_body
+
+
+async def test_change_requested_for_core_dev():
+    data = {
+        "action": "submitted",
+        "review": {
+            "user": {
+                "login": "gvanrossum",
+            },
+            "state": "changes_requested".upper(),
+        },
+        "pull_request": {
+            "url": "https://api.github.com/pr/42",
+            "issue_url": "https://api.github.com/issue/42",
+            "comments_url": "https://api.github.com/comment/42",
+            "user": {
+                "login": "brettcannon"
+            }
+        },
+    }
+    event = sansio.Event(data, event="pull_request_review", delivery_id="12345")
+    teams = [
+        {"name": "python core", "id": 6}
+    ]
+    items = {
+        f"https://api.github.com/teams/6/memberships/gvanrossum": True,
+        "https://api.github.com/teams/6/memberships/brettcannon": True,
+        "https://api.github.com/issue/42": {
+            "labels": [],
+            "labels_url": "https://api.github.com/labels/42",
+        }
+    }
+    iterators = {
+        "https://api.github.com/orgs/python/teams": teams,
+        "https://api.github.com/pr/42/reviews":
+            [{"user": {"login": "brettcannon"}, "state": "changes_requested"}],
+    }
+    gh = FakeGH(getiter=iterators, getitem=items)
+    await awaiting.router.dispatch(event, gh)
+
+    assert len(gh.post_) == 2
+    labeling = gh.post_[0]
+    assert labeling[0] == "https://api.github.com/labels/42"
+    assert labeling[1] == [awaiting.Blocker.changes.value]
+    message = gh.post_[1]
+    assert message[0] == "https://api.github.com/comment/42"
+
+    core_dev_message = awaiting.CORE_DEV_CHANGES_REQUESTED_MESSAGE.replace(
+        "{easter_egg}", "").strip()
+    assert core_dev_message in message[1]["body"]
 
 
 async def test_awaiting_labels_removed_when_pr_merged():

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -274,7 +274,8 @@ async def test_new_review():
     event = sansio.Event(data, event="pull_request_review", delivery_id="12345")
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
-        f"https://api.github.com/teams/6/memberships/miss-islington": False,
+        f"https://api.github.com/teams/6/memberships/miss-islington":
+            gidgethub.BadRequest(status_code=http.HTTPStatus(404)),
         "https://api.github.com/issue/42": {
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -492,6 +492,57 @@ async def test_change_requested_for_core_dev():
     assert core_dev_message in message[1]["body"]
 
 
+async def test_change_requested_for_non_core_dev():
+    data = {
+        "action": "submitted",
+        "review": {
+            "user": {
+                "login": "gvanrossum",
+            },
+            "state": "changes_requested".upper(),
+        },
+        "pull_request": {
+            "url": "https://api.github.com/pr/42",
+            "issue_url": "https://api.github.com/issue/42",
+            "comments_url": "https://api.github.com/comment/42",
+            "user": {
+                "login": "miss-islington"
+            }
+        },
+    }
+    event = sansio.Event(data, event="pull_request_review", delivery_id="12345")
+    teams = [
+        {"name": "python core", "id": 6}
+    ]
+    items = {
+        f"https://api.github.com/teams/6/memberships/gvanrossum": True,
+        "https://api.github.com/teams/6/memberships/miss-islington":
+            gidgethub.BadRequest(status_code=http.HTTPStatus(404)),
+        "https://api.github.com/issue/42": {
+            "labels": [],
+            "labels_url": "https://api.github.com/labels/42",
+        }
+    }
+    iterators = {
+        "https://api.github.com/orgs/python/teams": teams,
+        "https://api.github.com/pr/42/reviews":
+            [{"user": {"login": "brettcannon"}, "state": "changes_requested"}],
+    }
+    gh = FakeGH(getiter=iterators, getitem=items)
+    await awaiting.router.dispatch(event, gh)
+
+    assert len(gh.post_) == 2
+    labeling = gh.post_[0]
+    assert labeling[0] == "https://api.github.com/labels/42"
+    assert labeling[1] == [awaiting.Blocker.changes.value]
+    message = gh.post_[1]
+    assert message[0] == "https://api.github.com/comment/42"
+
+    change_requested_message = awaiting.CHANGES_REQUESTED_MESSAGE.replace(
+        "{easter_egg}", "").strip()
+    assert change_requested_message in message[1]["body"]
+
+
 async def test_awaiting_labels_removed_when_pr_merged():
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"
     data = {


### PR DESCRIPTION
Follow up from [core-workflow](https://mail.python.org/mm3/archives/list/core-workflow@python.org/thread/H5CRUS6AHTTJDXWUAMJZWKXEAMMRQPM3/) email thread.

The change requested message is now shorter when PR author is a core dev:
```
When you're done making the requested changes, leave the comment:
`I have made the requested changes; please review again`
```