### PR TITLE
Fix two typos

### DIFF
--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -16,7 +16,7 @@ MESSAGE_TEMPLATE = ('[GH-{pr}](https://github.com/python/cpython/pull/{pr}) is '
 
 
 async def _copy_over_labels(gh, original_issue, backport_issue):
-    """Copy over relevent labels from the original PR to the backport PR."""
+    """Copy over relevant labels from the original PR to the backport PR."""
     label_prefixes = "skip", "type", "sprint"
     labels = list(filter(lambda x: x.startswith(label_prefixes),
                     util.labels(original_issue)))

--- a/tests/test_bpo.py
+++ b/tests/test_bpo.py
@@ -180,7 +180,7 @@ async def test_new_label_not_skip_issue():
 
 @pytest.mark.asyncio
 async def test_removed_label_from_label_deletion():
-    """When a label is completely deleted from a repo, it triggers an 'unlabled'
+    """When a label is completely deleted from a repo, it triggers an 'unlabeled'
     event, but the payload has no details about the removed label."""
     data = {
         "action": "unlabeled",


### PR DESCRIPTION
old | new
--- | ---
  `relevent` | `relevant`
  `unlabled` | `unlabeled`