### PR TITLE
Fix issue where PR without any description has its title edited

### DIFF
--- a/bedevere/bpo.py
+++ b/bedevere/bpo.py
@@ -43,7 +43,7 @@ async def set_status(event, gh, *args, **kwargs):
     else:
         if "body" in event.data["pull_request"]:
             body = event.data["pull_request"]["body"]
-            if CLOSING_TAG not in body:
+            if not body or CLOSING_TAG not in body:
                 issue_number = issue_number_found.group("issue")
                 new_body = BODY.format(body=body, issue_number=issue_number)
                 body_data = {"body": new_body, "maintainer_can_modify": True}

--- a/tests/test_bpo.py
+++ b/tests/test_bpo.py
@@ -110,6 +110,26 @@ async def test_edit_title():
 
 
 @pytest.mark.asyncio
+async def test_no_body_when_edit_title():
+    data = {
+        "action": "edited",
+        "pull_request": {
+            "url": "https://api.github.com/repos/python/cpython/pulls/5291",
+            "title": "bpo-32636: Fix @asyncio.coroutine debug mode bug",
+            "body": None,
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/98d60953c85df9f0f28e04322a4c4ebec7b180f4",
+        },
+        "changes": {
+            "title": "bpo-32636: Fix @asyncio.coroutine debug mode bug exposed by #5250."
+        },
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="12345")
+    gh = FakeGH()
+    await bpo.router.dispatch(event, gh)
+    assert gh.data is not None
+
+
+@pytest.mark.asyncio
 async def test_edit_other_than_title():
     data = {
         "pull_request": {


### PR DESCRIPTION
This came up in https://github.com/python/cpython/pull/5291

The PR did not have any description, and the title was
edited to include the bpo number.
It caused a 500 error, because bedevere did not anticipate
this situation.

Updated the code so that it takes into consideration when the
body is empty.