### PR TITLE
Use Python 3.7.0 in Heroku

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.6
+python-3.7.0


### PR DESCRIPTION
Heroku now supports Python 3.7.0.
https://devcenter.heroku.com/articles/python-runtimes