### PR TITLE
Improve two testcases to test all labels

### DIFF
--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -542,7 +542,16 @@ async def test_change_requested_for_non_core_dev():
     assert change_requested_message in message[1]["body"]
 
 
-async def test_awaiting_labels_removed_when_pr_merged():
+@pytest.mark.parametrize('label', [
+    'awaiting change review',
+    'awaiting changes',
+    'awaiting core review',
+    'awaiting merge',
+    'awaiting review',
+])
+async def test_awaiting_labels_removed_when_pr_merged(label):
+    encoded_label = label.replace(' ', '%20')
+
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"
     data = {
         "action": "closed",
@@ -556,8 +565,8 @@ async def test_awaiting_labels_removed_when_pr_merged():
     issue_data = {
         issue_url: {
             "labels": [
-                {"url": "https://api.github.com/repos/python/cpython/labels/awaiting%20merge",
-                 "name": "awaiting merge",
+                {"url": "https://api.github.com/repos/python/cpython/labels/" + encoded_label,
+                 "name": label,
                  },
                 {
                   "url": "https://api.github.com/repos/python/cpython/labels/CLA%20signed",
@@ -571,10 +580,17 @@ async def test_awaiting_labels_removed_when_pr_merged():
     gh = FakeGH(getitem=issue_data)
 
     await awaiting.router.dispatch(event, gh)
-    assert gh.delete_url == "https://api.github.com/repos/python/cpython/issues/12345/labels/awaiting%20merge"
+    assert gh.delete_url == "https://api.github.com/repos/python/cpython/issues/12345/labels/" + encoded_label
 
 
-async def test_awaiting_labels_not_removed_when_pr_not_merged():
+@pytest.mark.parametrize('label', [
+    'awaiting change review',
+    'awaiting changes',
+    'awaiting core review',
+    'awaiting merge',
+    'awaiting review',
+])
+async def test_awaiting_labels_not_removed_when_pr_not_merged(label):
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"
     data = {
         "action": "closed",
@@ -588,8 +604,8 @@ async def test_awaiting_labels_not_removed_when_pr_not_merged():
     issue_data = {
         issue_url: {
             "labels": [
-                {"url": "https://api.github.com/repos/python/cpython/labels/awaiting%20merge",
-                 "name": "awaiting merge",
+                {"url": "https://api.github.com/repos/python/cpython/labels/" + label.replace(' ', '%20'),
+                 "name": label,
                  },
                 {
                   "url": "https://api.github.com/repos/python/cpython/labels/CLA%20signed",

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -542,13 +542,16 @@ async def test_change_requested_for_non_core_dev():
     assert change_requested_message in message[1]["body"]
 
 
-@pytest.mark.parametrize('label', [
+labels = (
     'awaiting change review',
     'awaiting changes',
     'awaiting core review',
     'awaiting merge',
     'awaiting review',
-])
+)
+
+
+@pytest.mark.parametrize('label', labels)
 async def test_awaiting_labels_removed_when_pr_merged(label):
     encoded_label = label.replace(' ', '%20')
 
@@ -565,7 +568,7 @@ async def test_awaiting_labels_removed_when_pr_merged(label):
     issue_data = {
         issue_url: {
             "labels": [
-                {"url": "https://api.github.com/repos/python/cpython/labels/" + encoded_label,
+                {"url": f"https://api.github.com/repos/python/cpython/labels/{encoded_label}",
                  "name": label,
                  },
                 {
@@ -580,17 +583,13 @@ async def test_awaiting_labels_removed_when_pr_merged(label):
     gh = FakeGH(getitem=issue_data)
 
     await awaiting.router.dispatch(event, gh)
-    assert gh.delete_url == "https://api.github.com/repos/python/cpython/issues/12345/labels/" + encoded_label
+    assert gh.delete_url == f"https://api.github.com/repos/python/cpython/issues/12345/labels/{encoded_label}"
 
 
-@pytest.mark.parametrize('label', [
-    'awaiting change review',
-    'awaiting changes',
-    'awaiting core review',
-    'awaiting merge',
-    'awaiting review',
-])
+@pytest.mark.parametrize('label', labels)
 async def test_awaiting_labels_not_removed_when_pr_not_merged(label):
+    encoded_label = label.replace(' ', '%20')
+
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"
     data = {
         "action": "closed",
@@ -604,7 +603,7 @@ async def test_awaiting_labels_not_removed_when_pr_not_merged(label):
     issue_data = {
         issue_url: {
             "labels": [
-                {"url": "https://api.github.com/repos/python/cpython/labels/" + label.replace(' ', '%20'),
+                {"url": f"https://api.github.com/repos/python/cpython/labels/{encoded_label}",
                  "name": label,
                  },
                 {

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -543,17 +543,17 @@ async def test_change_requested_for_non_core_dev():
 
 
 awaiting_labels = (
-    'awaiting change review',
-    'awaiting changes',
-    'awaiting core review',
-    'awaiting merge',
-    'awaiting review',
+    "awaiting change review",
+    "awaiting changes",
+    "awaiting core review",
+    "awaiting merge",
+    "awaiting review",
 )
 
 
-@pytest.mark.parametrize('label', awaiting_labels)
+@pytest.mark.parametrize("label", awaiting_labels)
 async def test_awaiting_label_removed_when_pr_merged(label):
-    encoded_label = label.replace(' ', '%20')
+    encoded_label = label.replace(" ", "%20")
 
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"
     data = {
@@ -586,9 +586,9 @@ async def test_awaiting_label_removed_when_pr_merged(label):
     assert gh.delete_url == f"https://api.github.com/repos/python/cpython/issues/12345/labels/{encoded_label}"
 
 
-@pytest.mark.parametrize('label', awaiting_labels)
+@pytest.mark.parametrize("label", awaiting_labels)
 async def test_awaiting_label_not_removed_when_pr_not_merged(label):
-    encoded_label = label.replace(' ', '%20')
+    encoded_label = label.replace(" ", "%20")
 
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"
     data = {

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -542,7 +542,7 @@ async def test_change_requested_for_non_core_dev():
     assert change_requested_message in message[1]["body"]
 
 
-labels = (
+awaiting_labels = (
     'awaiting change review',
     'awaiting changes',
     'awaiting core review',
@@ -551,8 +551,8 @@ labels = (
 )
 
 
-@pytest.mark.parametrize('label', labels)
-async def test_awaiting_labels_removed_when_pr_merged(label):
+@pytest.mark.parametrize('label', awaiting_labels)
+async def test_awaiting_label_removed_when_pr_merged(label):
     encoded_label = label.replace(' ', '%20')
 
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"
@@ -586,8 +586,8 @@ async def test_awaiting_labels_removed_when_pr_merged(label):
     assert gh.delete_url == f"https://api.github.com/repos/python/cpython/issues/12345/labels/{encoded_label}"
 
 
-@pytest.mark.parametrize('label', labels)
-async def test_awaiting_labels_not_removed_when_pr_not_merged(label):
+@pytest.mark.parametrize('label', awaiting_labels)
+async def test_awaiting_label_not_removed_when_pr_not_merged(label):
     encoded_label = label.replace(' ', '%20')
 
     issue_url = "https://api.github.com/repos/org/proj/issues/3749"


### PR DESCRIPTION
This PR addresses Mariatta's comment in #113 regarding the addition of test cases to test the removal of all labels.

Closes https://github.com/python/bedevere/issues/113