### PR TITLE
leave codeblocks untouched while hyperlinking

### DIFF
--- a/bedevere/bpo.py
+++ b/bedevere/bpo.py
@@ -140,17 +140,22 @@ def create_hyperlink_in_comment_body(body):
     new_body = ""
     leftover_body = body
     ISSUE_RE = re.compile(r"bpo-(?P<issue>\d+)")
-
-    # leave code blocks, inline or otherwise, untouched
-    CODE_BLOCK = re.compile(r"(`{1,3})(.|\s)*(`{1,3})")
-    if CODE_BLOCK.search(body):
-        return body
+    CODE_BLOCK = re.compile(r"(`{3}([^`]*?)`{3})|(^`([^`]*?)`$)")  # leave code blocks, inline or otherwise, untouched
 
     while True:
         match = ISSUE_RE.search(leftover_body)
+        codeblock_match = CODE_BLOCK.search(leftover_body)
+
         if match is None:
             break
+
         presence = check_hyperlink(match)
+        if codeblock_match:
+            temp = leftover_body
+            new_body += leftover_body[:codeblock_match.end()]
+            # new_body += leftover_body[codeblock_match.end():] leftover_body = leftover_body[codeblock_match.end():]
+            new_body = temp
+            break
         if presence is False:
             new_body = new_body + leftover_body[:match.start()]
             leftover_body = leftover_body[match.end():]
@@ -158,6 +163,7 @@ def create_hyperlink_in_comment_body(body):
         else:
             new_body = new_body + leftover_body[:presence]
             leftover_body = leftover_body[presence:]
+
     new_body = new_body + leftover_body
 
     return new_body

--- a/bedevere/bpo.py
+++ b/bedevere/bpo.py
@@ -115,7 +115,7 @@ def check_hyperlink(match):
     """The span checking of regex matches takes care of cases like bpo-123 [bpo-123]…"""
     issue = match.group("issue")
     markdown_link_re = re.compile(r"""
-                                    \[\s*bpo-(?P<issue>{issue})\s*\]   
+                                    \[\s*bpo-(?P<issue>{issue})\s*\]
                                     \(\s*https://bugs.python.org/issue{issue}\s*\)""".format(issue=issue),
                                     re.VERBOSE)
     html_link_re = re.compile(r""" <a
@@ -140,6 +140,12 @@ def create_hyperlink_in_comment_body(body):
     new_body = ""
     leftover_body = body
     ISSUE_RE = re.compile(r"bpo-(?P<issue>\d+)")
+
+    # leave code blocks, inline or otherwise, untouched
+    CODE_BLOCK = re.compile(r"(`{1,3})(.|\s)*(`{1,3})")
+    if CODE_BLOCK.search(body):
+        return body
+
     while True:
         match = ISSUE_RE.search(leftover_body)
         if match is None:
@@ -153,4 +159,5 @@ def create_hyperlink_in_comment_body(body):
             new_body = new_body + leftover_body[:presence]
             leftover_body = leftover_body[presence:]
     new_body = new_body + leftover_body
+
     return new_body


### PR DESCRIPTION
Almost always, we would want the text inside a code block to be the way it is/untouched. This has, previously, lead to a few problems in discussions and otherwise. See the discussion over at #136.

Closes #136 