### PR TITLE
Provide link to blurb-it

### DIFF
--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -13,7 +13,7 @@ router = gidgethub.routing.Router()
 
 create_status = functools.partial(util.create_status, 'bedevere/news')
 
-DEVGUIDE_URL = 'https://devguide.python.org/committing/#what-s-new-and-news-entries'
+BLURB_IT_URL = 'https://blurb-it.herokuapp.com'
 
 FILENAME_RE = re.compile(r"""# YYYY-mm-dd or YYYY-mm-dd-HH-MM-SS
                              \d{4}-\d{2}-\d{2}(?:-\d{2}-\d{2}-\d{2})?\.
@@ -60,7 +60,7 @@ async def check_news(gh, pull_request, files=None):
                 description = "News entry file name incorrectly formatted"
             status = create_status(util.StatusState.FAILURE,
                                    description=description,
-                                   target_url=DEVGUIDE_URL)
+                                   target_url=BLURB_IT_URL)
 
     await gh.post(pull_request['statuses_url'], data=status)
 

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -71,6 +71,7 @@ async def failure_testing(path, action):
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert gh.post_url == 'https://api.github.com/some/status'
     assert gh.post_data['state'] == 'failure'
+    assert gh.post_data['target_url'] == news.BLURB_IT_URL
 
 
 @pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
@@ -106,6 +107,7 @@ async def test_skip_news(action):
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert gh.post_url == 'https://api.github.com/some/status'
     assert gh.post_data['state'] == 'success'
+    assert gh.post_data.get('target_url') is None
 
 
 @pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
@@ -128,6 +130,7 @@ async def test_news_file(action):
     assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
     assert gh.post_url == 'https://api.github.com/some/status'
     assert gh.post_data['state'] == 'success'
+    assert gh.post_data.get('target_url') is None
 
 
 @pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
@@ -150,6 +153,7 @@ async def test_empty_news_file(action):
     assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
     assert gh.post_url == 'https://api.github.com/some/status'
     assert gh.post_data['state'] == 'failure'
+    assert gh.post_data['target_url'] == news.BLURB_IT_URL
 
 
 @pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
@@ -171,6 +175,7 @@ async def test_news_file_too_short(action):
     assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
     assert gh.post_url == 'https://api.github.com/some/status'
     assert gh.post_data['state'] == 'failure'
+    assert gh.post_data['target_url'] == news.BLURB_IT_URL
 
 
 async def test_adding_skip_news_label():


### PR DESCRIPTION
When a PR is missing a news entry, link to blurb-it instead of devguide.