### PR TITLE
Don't pass `maintainer_can_modify` when patching the PR.

### DIFF
--- a/bedevere/bpo.py
+++ b/bedevere/bpo.py
@@ -47,7 +47,7 @@ async def set_status(event, gh, *args, **kwargs):
             if not body or CLOSING_TAG not in body:
                 issue_number = issue_number_found.group("issue")
                 new_body = BODY.format(body=body, issue_number=issue_number)
-                body_data = {"body": new_body, "maintainer_can_modify": True}
+                body_data = {"body": new_body}
                 await gh.patch(event.data["pull_request"]["url"], data=body_data)
         status = create_success_status(issue_number_found)
     await util.post_status(gh, event, status)
@@ -98,7 +98,7 @@ async def hyperlink_bpo_text(event, gh, *args, **kwargs):
         body = event.data[event_name]["body"] or ""
         new_body = create_hyperlink_in_comment_body(body)
         if new_body != body:
-            body_data = {"body": new_body, "maintainer_can_modify": True}
+            body_data = {"body": new_body}
             await gh.patch(event.data[event_name][body_location], data=body_data)
 
 

--- a/bedevere/close_pr.py
+++ b/bedevere/close_pr.py
@@ -29,8 +29,7 @@ async def close_invalid_pr(event, gh, *args, **kwargs):
 
     if PYTHON_MAINT_BRANCH_RE.match(head_label) and \
         base_label == "python:master":
-        data = {'state': 'closed',
-                'maintainer_can_modify': True}
+        data = {'state': 'closed'}
         await gh.patch(event.data["pull_request"]["url"], data=data)
         await gh.post(
             f'{event.data["pull_request"]["issue_url"]}/labels',

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.2
+python-3.7.3


### PR DESCRIPTION
We used to need to pass the `maintainer_can_modify` flag, but now we're getting error message `422 Validation Failed for 'maintainer_can_modify'` when patching the PR. (to append the bpo link)

Removing the `maintainer_can_modify` flag fixes the problem, I tested in command line.
Hopefully this quick fix can unblock people.

Perhaps something changed from GitHub side, but I'm not seeing anything obvious in [their changelog](https://github.blog/changelog/).

Closes #162 
Closes https://github.com/python/core-workflow/issues/321


