### PR TITLE
Avoid putting new bpo links inside of existing links

### DIFF
--- a/bedevere/bpo.py
+++ b/bedevere/bpo.py
@@ -117,7 +117,7 @@ def check_hyperlink(match):
     """The span checking of regex matches takes care of cases like bpo-123 [bpo-123]…"""
     issue = match.group("issue")
     markdown_link_re = re.compile(r"""
-                                    \[\s*bpo-(?P<issue>{issue})\s*\]   
+                                    \[[^\]]*bpo-(?P<issue>{issue})[^\]]*\]
                                     \(\s*https://bugs.python.org/issue{issue}\s*\)""".format(issue=issue),
                                     re.VERBOSE)
     html_link_re = re.compile(r""" <a

--- a/bedevere/bpo.py
+++ b/bedevere/bpo.py
@@ -141,7 +141,6 @@ def create_hyperlink_in_comment_body(body):
     """Uses infinite loop for updating the string being searched dynamically."""
     new_body = ""
     leftover_body = body
-    ISSUE_RE = re.compile(r"bpo-(?P<issue>\d+)")
     while True:
         match = ISSUE_RE.search(leftover_body)
         if match is None:

--- a/tests/test_bpo.py
+++ b/tests/test_bpo.py
@@ -391,6 +391,7 @@ async def test_set_pull_request_body_already_hyperlinked_bpo(action):
             "issue_url": "https://api.github.com/repos/blah/blah/issues/comments/123456",
             "body": ("bpo-123"
                     "[bpo-123](https://bugs.python.org/issue123)"
+                    "[something about bpo-123](https://bugs.python.org/issue123)"
                     "<a href='https://bugs.python.org/issue123'>bpo-123</a>"
                    )
         },
@@ -402,6 +403,7 @@ async def test_set_pull_request_body_already_hyperlinked_bpo(action):
     await bpo.router.dispatch(event, gh)
     body_data = gh.patch_data
     assert body_data["body"].count("[bpo-123](https://bugs.python.org/issue123)") == 2
+    assert body_data["body"].count("[something about bpo-123](https://bugs.python.org/issue123)") == 1
     assert "123456" in gh.patch_url
 
 
@@ -417,6 +419,7 @@ async def test_set_comment_body_already_hyperlinked_bpo(event, action):
             "url": "https://api.github.com/repos/blah/blah/issues/comments/123456",
             "body": ("bpo-123"
                     "[bpo-123](https://bugs.python.org/issue123)"
+                    "[something about bpo-123](https://bugs.python.org/issue123)"
                     "<a href='https://bugs.python.org/issue123'>bpo-123</a>"
                    )
         }
@@ -427,4 +430,5 @@ async def test_set_comment_body_already_hyperlinked_bpo(event, action):
     await bpo.router.dispatch(event, gh)
     body_data = gh.patch_data
     assert body_data["body"].count("[bpo-123](https://bugs.python.org/issue123)") == 2
+    assert body_data["body"].count("[something about bpo-123](https://bugs.python.org/issue123)") == 1
     assert "123456" in gh.patch_url

--- a/tests/test_bpo.py
+++ b/tests/test_bpo.py
@@ -316,7 +316,7 @@ async def test_set_pull_request_body_success(action):
     assert "123456" in gh.patch_url
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("event,action", [("issue_comment", "created"), 
+@pytest.mark.parametrize("event,action", [("issue_comment", "created"),
                                           ("issue_comment", "edited"),
                                           ("commit_comment", "created"),
                                           ("commit_comment", "edited")])
@@ -359,7 +359,7 @@ async def test_set_pull_request_body_without_bpo(action):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("event,action", [("issue_comment", "created"), 
+@pytest.mark.parametrize("event,action", [("issue_comment", "created"),
                                           ("issue_comment", "edited"),
                                           ("commit_comment", "created"),
                                           ("commit_comment", "edited")])
@@ -406,7 +406,7 @@ async def test_set_pull_request_body_already_hyperlinked_bpo(action):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("event,action", [("issue_comment", "created"), 
+@pytest.mark.parametrize("event,action", [("issue_comment", "created"),
                                           ("issue_comment", "edited"),
                                           ("commit_comment", "created"),
                                           ("commit_comment", "edited")])


### PR DESCRIPTION
Also includes minor code cleanup.

Fixes #164.