### PR TITLE
Remove test against 3.6 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 cache: pip
 python:
-  - 3.6
   - 3.7
   - 3.7-dev
   - 3.8-dev


### PR DESCRIPTION
Technically we're running it in 3.7+