### PR TITLE
Automatically create "needs backport to" label when maintenance branch created.

### DIFF
--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -105,6 +105,9 @@ async def validate_maintenance_branch_pr(event, gh, *args, **kwargs):
 async def maintenance_branch_created(event, gh, *args, **kwargs):
     """Create the needs backport label when maintenance branch created.
 
+    Also post a reminder to add the maintenance branch to the list of
+    `ALLOWED_BRANCHES` in CPython-emailer-webhook.
+
     If a maintenance branch was created (e.g.: 3.9, or 4.0),
     automatically create the `needs backport to ` label.
 
@@ -116,6 +119,17 @@ async def maintenance_branch_created(event, gh, *args, **kwargs):
     if title_match:
         await gh.post(
             "/repos/python/cpython/labels",
-            data={'name': f'needs backport to {branch_name}',
-                  'color': '#c2e0c6'
-                  })
+            data={"name": f"needs backport to {branch_name}", "color": "#c2e0c6"},
+        )
+
+        await gh.post(
+            "/repos/berkerpeksag/cpython-emailer-webhook/issues",
+            data={
+                "title": f"Please add {branch_name} to ALLOWED_BRANCHES",
+                "body": (
+                    f"A new CPython maintenance branch `{branch_name}` has just been created.",
+                    "\nThis is a reminder to add `{branch_name}` to the list of `ALLOWED_BRANCHES`",
+                    "\nhttps://github.com/berkerpeksag/cpython-emailer-webhook/blob/e164cb9a6735d56012a4e557fd67dd7715c16d7b/mailer.py#L15",
+                ),
+            },
+        )

--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -116,7 +116,7 @@ async def maintenance_branch_created(event, gh, *args, **kwargs):
     branch_name = event.data["ref"]
     title_match = MAINTENANCE_BRANCH_RE.match(branch_name)
 
-    if title_match:
+    if MAINTENANCE_BRANCH_RE.match(branch_name):
         await gh.post(
             "/repos/python/cpython/labels",
             data={"name": f"needs backport to {branch_name}", "color": "#c2e0c6"},

--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -103,7 +103,7 @@ async def validate_maintenance_branch_pr(event, gh, *args, **kwargs):
 
 @router.register("create", ref_type="branch")
 async def maintenance_branch_created(event, gh, *args, **kwargs):
-    """Create the needs backport label when maintenance branch created.
+    """Create the `needs backport label` when the maintenance branch is created.
 
     Also post a reminder to add the maintenance branch to the list of
     `ALLOWED_BRANCHES` in CPython-emailer-webhook.

--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -13,6 +13,7 @@ router = gidgethub.routing.Router()
 
 TITLE_RE = re.compile(r'\s*\[(?P<branch>\d+\.\d+)\].+\((?:GH-|#)(?P<pr>\d+)\)')
 MAINTENANCE_BRANCH_TITLE_RE = re.compile(r'\s*\[(?P<branch>\d+\.\d+)\].+')
+MAINTENANCE_BRANCH_RE = re.compile(r'\s*(?P<branch>\d+\.\d+)')
 BACKPORT_LABEL = 'needs backport to {branch}'
 MESSAGE_TEMPLATE = ('[GH-{pr}](https://github.com/python/cpython/pull/{pr}) is '
                     'a backport of this pull request to the '
@@ -98,3 +99,23 @@ async def validate_maintenance_branch_pr(event, gh, *args, **kwargs):
         status = create_status(util.StatusState.SUCCESS,
                                description="Valid maintenance branch PR title.")
     await util.post_status(gh, event, status)
+
+
+@router.register("create", ref_type="branch")
+async def maintenance_branch_created(event, gh, *args, **kwargs):
+    """Create the needs backport label when maintenance branch created.
+
+    If a maintenance branch was created (e.g.: 3.9, or 4.0),
+    automatically create the `needs backport to ` label.
+
+    The maintenance branch PR has to start with `[X.Y]`
+    """
+    branch_name = event.data["ref"]
+    title_match = MAINTENANCE_BRANCH_RE.match(branch_name)
+
+    if title_match:
+        await gh.post(
+            "/repos/python/cpython/labels",
+            data={'name': f'needs backport to {branch_name}',
+                  'color': '#c2e0c6'
+                  })

--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -114,7 +114,6 @@ async def maintenance_branch_created(event, gh, *args, **kwargs):
     The maintenance branch PR has to start with `[X.Y]`
     """
     branch_name = event.data["ref"]
-    title_match = MAINTENANCE_BRANCH_RE.match(branch_name)
 
     if MAINTENANCE_BRANCH_RE.match(branch_name):
         await gh.post(

--- a/tests/test_backport.py
+++ b/tests/test_backport.py
@@ -359,9 +359,13 @@ async def test_maintenance_branch_created(ref):
                         delivery_id='1')
     gh = FakeGH()
     await backport.router.dispatch(event, gh)
-    post = gh.post_[0]
-    assert post[0] == "https://api.github.com/repos/python/cpython/labels"
-    assert post[1] == {'name': f"needs backport to {ref}", 'color': '#c2e0c6'}
+    label_creation_post = gh.post_[0]
+    assert label_creation_post[0] == "https://api.github.com/repos/python/cpython/labels"
+    assert label_creation_post[1] == {'name': f"needs backport to {ref}", 'color': '#c2e0c6'}
+
+    issue_creation_post = gh.post_[1]
+    assert issue_creation_post[0] == "https://api.github.com/repos/berkerpeksag/cpython-emailer-webhook/issues"
+    assert issue_creation_post[1]['title'] == f"Please add {ref} to ALLOWED_BRANCHES"
 
 
 @pytest.mark.parametrize('ref', ['backport-3.9', 'test', 'Mariatta-patch-1'])


### PR DESCRIPTION
Creating label is boring. With this PR, bedevere will automatically
create the `needs backport to ` label when a maintenance branch
is created under CPython repo.

Maintenance branch has the pattern: 3.9, 4.0, 3.10, ...

- [x] enable the `Branch or Tag` creation webhook in CPython.