### PR TITLE
Fix PR state machine graph

### DIFF
--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -32,7 +32,7 @@ digraph "PR stages" {
   "Awaiting review" -> "Awaiting changes" [label="New review requests changes", color=green]
   "Awaiting core review" -> "Awaiting merge" [label="New review approves", color=green]
 
-  "New PR" -> "Awaiting merge" [label="New PR", color=green]
+  "New PR" -> "Awaiting core review" [label="New PR", color=green]
 }
 """
 


### PR DESCRIPTION
After #158 has been merged, the state machine graph was out of date.
This update fixes the transition from "New PR" for core developers to
"Awaiting core review" instead of "Awaiting merge".

### Before

![graphviz](https://user-images.githubusercontent.com/153842/62002672-e69c3e80-b0d6-11e9-965c-027b06a05d67.png)

### After

![graphviz (1)](https://user-images.githubusercontent.com/153842/62002674-e9972f00-b0d6-11e9-9072-d5974e892eb3.png)
