### PR TITLE
Removing Monty Python joke refference links.

### DIFF
--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -81,12 +81,12 @@ When you're done making the requested changes, leave the comment: `{BORING_TRIGG
 
 EASTER_EGG_1 = """\
 And if you don't make the requested changes, \
-[you will be poked with soft cushions!](https://youtu.be/XnS49c9KZw8?t=1m7s)
+you will be poked with soft cushions!
 """
 
 EASTER_EGG_2 = """\
 And if you don't make the requested changes, \
-[you will be put in the comfy chair!](https://youtu.be/XnS49c9KZw8?t=1m30s)
+you will be put in the comfy chair!
 """
 
 ACK = """\
@@ -95,7 +95,7 @@ ACK = """\
 {core_devs}: please review the changes made to this pull request.
 """
 BORING_THANKS = "Thanks for making the requested changes!"
-FUN_THANKS = "[Nobody expects the Spanish Inquisition!](https://youtu.be/QqreRufrkxM)"
+FUN_THANKS = "Nobody expects the Spanish Inquisition!"
 
 
 LABEL_PREFIX = "awaiting"


### PR DESCRIPTION
As the video references to jokes from Monty Python are continually removed from YouTube, the links to those videos are removed.

Fixes #201 