### PR TITLE
Do not apply the 'awaiting merge' label on a closed PR

### DIFF
--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -203,7 +203,10 @@ async def new_review(event, gh, *args, **kwargs):
             )
     else:
         if state == "approved":
-            await stage(gh, await util.issue_for_PR(gh, pull_request), Blocker.merge)
+            if pull_request["state"] == "open":
+                await stage(
+                    gh, await util.issue_for_PR(gh, pull_request), Blocker.merge
+                )
         elif state == "changes_requested":
             issue = await util.issue_for_PR(gh, pull_request)
             if Blocker.changes.value in util.labels(issue):


### PR DESCRIPTION
If an approval comes after the PR has been merged, bedevere still
applies the `awaiting merge` label, which might cause confusion
when searching for PRs with that label.

Fixes #291.