### PR TITLE
Use Python 3.9.1

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.6
+python-3.9.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.0
+python-3.9.1


### PR DESCRIPTION
In #309 I've added Python 3.9 and Python 3.9-dev to the CI job, and disallowed failure on those versions.

Closes #280