### PR TITLE
Remove unused `filterwarnings` from `pytest.ini`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths = tests
+# https://github.com/pytest-dev/pytest-asyncio#modes
+asyncio_mode = auto

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,2 @@
 [pytest]
 testpaths = tests
-filterwarnings =
-    error
-    ignore::DeprecationWarning
-    ignore::pytest.PytestUnraisableExceptionWarning


### PR DESCRIPTION
`filterwarnings` with extra warning types might be problematic, because it can hide some important messages in the future.

I've checked that right now there are no warnings (and no point in keeping it):
- 3.8: https://github.com/sobolevn/bedevere/runs/5302010464?check_suite_focus=true#step:7:29
- 3.9: https://github.com/sobolevn/bedevere/runs/5302010520?check_suite_focus=true#step:7:29
- 3.10: https://github.com/sobolevn/bedevere/runs/5302010602?check_suite_focus=true#step:7:29

Docs about new `asyncio-mode` setting: https://github.com/pytest-dev/pytest-asyncio#modes