### PR TITLE
Use the new "type" labels after GH migration.

### DIFF
--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -4,18 +4,19 @@ import pathlib
 
 from . import util
 
-LABEL_PREFIX = "type"
+TYPE_LABEL_PREFIX = "type"
 
 
 @enum.unique
 class Category(enum.Enum):
     """Category of Pull Request."""
-    bugfix = f"{LABEL_PREFIX}-bugfix"
-    documentation = f"{LABEL_PREFIX}-documentation"
-    enhancement = f"{LABEL_PREFIX}-enhancement"
-    performance = f"{LABEL_PREFIX}-performance"
-    security = f"{LABEL_PREFIX}-security"
-    tests = f"{LABEL_PREFIX}-tests"
+
+    type_bug = f"{TYPE_LABEL_PREFIX}-bug"
+    documentation = "docs"
+    type_feature = f"{TYPE_LABEL_PREFIX}-feature"
+    performance = "performance"
+    type_security = f"{TYPE_LABEL_PREFIX}-security"
+    tests = "tests"
 
 
 async def add_category(gh, issue, category):

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -4,6 +4,8 @@ from gidgethub import sansio
 
 from bedevere import filepaths
 
+from bedevere.prtype import Category
+
 
 class FakeGH:
 
@@ -82,7 +84,7 @@ async def test_docs_only():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'failure'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == ['type-documentation']
+    assert gh.post_data[1] == [Category.documentation.value]
 
 
 async def test_tests_only():
@@ -109,7 +111,7 @@ async def test_tests_only():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'failure'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == ['type-tests']
+    assert gh.post_data[1] == [Category.tests.value]
 
 
 async def test_docs_and_tests():
@@ -137,7 +139,7 @@ async def test_docs_and_tests():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'success'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == ['type-tests']
+    assert gh.post_data[1] == [Category.tests.value]
 
 
 async def test_news_and_tests():
@@ -166,7 +168,7 @@ async def test_news_and_tests():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'success'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == ['type-tests']
+    assert gh.post_data[1] == [Category.tests.value]
 
 
 async def test_synchronize():

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -1,4 +1,5 @@
 from bedevere import prtype
+from bedevere.prtype import Category
 
 
 class FakeGH:
@@ -84,7 +85,7 @@ async def test_docs_no_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == ['type-documentation']
+    assert gh.post_data[0] == [Category.documentation.value]
 
 
 async def test_docs_and_news():
@@ -105,7 +106,7 @@ async def test_docs_and_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == ['type-documentation']
+    assert gh.post_data[0] == [Category.documentation.value]
 
 
 async def test_tests_only():
@@ -126,7 +127,7 @@ async def test_tests_only():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == ['type-tests']
+    assert gh.post_data[0] == [Category.tests.value]
 
 
 async def test_docs_and_tests():
@@ -148,7 +149,7 @@ async def test_docs_and_tests():
     # Only creates type-tests label.
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == ['type-tests']
+    assert gh.post_data[0] == [Category.tests.value]
 
 
 async def test_leave_existing_type_labels():
@@ -190,7 +191,7 @@ async def test_news_and_tests():
     # Creates type-tests label.
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == ['type-tests']
+    assert gh.post_data[0] == [Category.tests.value]
 
 
 async def test_other_files():


### PR DESCRIPTION
Closes https://github.com/python/core-workflow/issues/432
