### PR TITLE
CI: Cache pip via setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-{{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
       - name: Install Dependencies
         run: |
           python3 -m pip install coverage -U pip


### PR DESCRIPTION
The https://github.com/actions/setup-python action can now take care of caching pip for us, so we don't need an explicit https://github.com/actions/cache step.

Docs: https://github.com/actions/setup-python#caching-packages-dependencies

(This partly a test for https://github.com/python/bedevere/issues/441)