### PR TITLE
Delete .codecov.yml and "comment: true"

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,1 +1,0 @@
-comment: true


### PR DESCRIPTION
Delete the `comment: true` from the YAML to hopefully workaround a Codecov bug and enable commenting on this repo.

As suggested in https://github.com/python/bedevere/issues/441#issuecomment-1110357378