### PR TITLE
Update comment: *almost* every change needs a NEWS entry

### DIFF
--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -28,11 +28,12 @@ SKIP_LABEL_STATUS = create_status(util.StatusState.SUCCESS,
                                   description='"skip news" label found')
 
 HELP = f"""\
-Every change to Python [requires a NEWS entry]\
+Almost every change to Python [requires a NEWS entry]\
 (https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python).
 
-Please, add it using the [blurb_it]({BLURB_IT_URL}) Web app or the [blurb]\
+Please add it using the [blurb_it]({BLURB_IT_URL}) web app or the [blurb]\
 ({BLURB_PYPI_URL}) command-line tool."""
+
 
 async def check_news(gh, pull_request, files=None):
     """Check for a news entry.

--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -28,7 +28,7 @@ SKIP_LABEL_STATUS = create_status(util.StatusState.SUCCESS,
                                   description='"skip news" label found')
 
 HELP = f"""\
-Almost every change to Python [requires a NEWS entry]\
+Most changes to Python [requires a NEWS entry]\
 (https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python).
 
 Please add it using the [blurb_it]({BLURB_IT_URL}) web app or the [blurb]\


### PR DESCRIPTION
Bedevere's comment is slightly misleading ([for example](https://github.com/python/cpython/pull/92121#issuecomment-1114957171
)):

> Every change to Python [requires a NEWS entry](https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python).
> 
> Please, add it using the [blurb_it](https://blurb-it.herokuapp.com) Web app or the [blurb](https://pypi.org/project/blurb/) command-line tool.

Bedevere's link to the devguide begins:

> Almost all changes made to the code base deserve an entry in `Misc/NEWS.d`.

And then details the exceptions.

Let's update Bedevere's comment to say "Almost every change ..." instead of "Every change ...".
