### PR TITLE
Rename `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bedevere
 
 [![Build Status](https://github.com/python/bedevere/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/python/bedevere/actions)
-[![codecov](https://codecov.io/gh/python/bedevere/branch/master/graph/badge.svg)](https://codecov.io/gh/python/bedevere)
+[![codecov](https://codecov.io/gh/python/bedevere/branch/main/graph/badge.svg)](https://codecov.io/gh/python/bedevere)
 
 This bot is meant to help identify issues with a CPython pull request.
 


### PR DESCRIPTION
Like other https://github.com/python repos, shall we rename the `master` branch to `main`?

An admin needs to do the rename at https://github.com/python/bedevere/settings/branches

This PR is the only code change in the repo.