### PR TITLE
Avoid running CI twice on PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: Tests
 
-on: [push, pull_request, workflow_dispatch]
-
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+  
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
   


### PR DESCRIPTION
I noticed that tests are run twice on each PR:
![image](https://user-images.githubusercontent.com/25624924/171003170-b8b019d9-b5ed-4fe8-b849-ac182ef6fd71.png)

This change avoids that by only running them once whenever a PR is created/updated, and then once it is merged with master.