### PR TITLE
Use Python version as flag for Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11.0-alpha - 3.11.0"]
-        include:
-        # Include new variables for Codecov
-        - python-version: "3.8"
-          codecov-flag: Python_3.8
-        - python-version: "3.9"
-          codecov-flag: Python_3.9
-        - python-version: "3.10"
-          codecov-flag: Python_3.10
-        - python-version: "3.11.0-alpha - 3.11.0"
-          codecov-flag: Python_3.11
+        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
       - uses: actions/checkout@v3
@@ -56,4 +46,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          flags: ${{ matrix.codecov-flag }}
+          flags: Python_${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,16 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11.0-alpha - 3.11.0"]
+        include:
+        # Include new variables for Codecov
+        - python-version: "3.8"
+          codecov-flag: Python_3.8
+        - python-version: "3.9"
+          codecov-flag: Python_3.9
+        - python-version: "3.10"
+          codecov-flag: Python_3.10
+        - python-version: "3.11.0-alpha - 3.11.0"
+          codecov-flag: Python_3.11
 
     steps:
       - uses: actions/checkout@v3
@@ -46,3 +56,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
+          flags: ${{ matrix.codecov-flag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           # https://github.com/aio-libs/yarl/issues/680
           YARL_NO_EXTENSIONS: 1
       - name: Run Tests
-        run: pytest --cov --cov-report=xml
+        run: pytest --cov --cov-report=term --cov-report=xml
       - uses: codecov/codecov-action@v2
         if: always()
         with:


### PR DESCRIPTION
Fixes https://github.com/python/bedevere/issues/462.

Re: https://github.com/python/bedevere/issues/462#issuecomment-1141391471

Two things here.

First add `-cov-report=term` to pytest, so we get output like this for 3.11 and can see coverage is missing (and 100% with 3.8-3.10):

```
Name                      Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------
bedevere/__init__.py          0      0      0      0   100%
bedevere/__main__.py         37      0      4      1    98%
bedevere/backport.py         63      0     36      0   100%
bedevere/close_pr.py         22      0     14      0   100%
bedevere/filepaths.py        15      0     12      0   100%
bedevere/gh_issue.py         72      0     34      1    99%
bedevere/news.py             51      0     28      0   100%
bedevere/prtype.py           33      0     19      0   100%
bedevere/stage.py           117      0     60      9    95%
bedevere/util.py             67      0     24      1    99%
tests/__init__.py             0      0      0      0   100%
tests/test___main__.py       25      0      0      0   100%
tests/test_backport.py      146      0     22      0   100%
tests/test_close_pr.py       95      0     16      0   100%
tests/test_filepaths.py     106      0      8      0   100%
tests/test_gh_issue.py      249      0     96      9    97%
tests/test_news.py          155      0     28      0   100%
tests/test_prtype.py        103      0      2      0   100%
tests/test_stage.py         291      0     10      0   100%
tests/test_util.py           73      0      6      0   100%
-----------------------------------------------------------
TOTAL                      1720      0    419     21    99%
```

https://github.com/hugovk/bedevere/runs/6665212616?check_suite_focus=true#step:6:27

Second, add a Python version as a flag to the Codecov upload in each matrix job.

This adds a dropdown to the file view:

<img width="654" alt="image" src="https://user-images.githubusercontent.com/1324225/171105534-3e3c0f0e-5d97-46c8-a40b-910b657035cf.png">

And for example selecting Python_3.11 shows these uncovered lines:

<img width="834" alt="image" src="https://user-images.githubusercontent.com/1324225/171105757-b77fc785-d252-41f8-b994-0529cd5509dc.png">

https://app.codecov.io/gh/hugovk/bedevere/blob/300b7d0ed649e9535c59db9824e9d1b041080839/bedevere/stage.py

# Note

The flag must have no spaces as it's used as a URL parameter during upload.

We could skip those `include` lines that define `matrix.codecov_flag` and instead use `flags: Python_${{ matrix.python_version }}`, except it wouldn't work for the `"3.11.0-alpha - 3.11.0"` version.

We could replace `""3.11.0-alpha - 3.11.0"` with `3.11-dev` instead, as far as I know that does the same thing, and is better: it has no upper limit of the .0 final version. For example `3.10-dev` is pointing to 3.10.4. And anyway, when 3.11.0 comes out, we're going to replace it with `"3.11"`.
