### PR TITLE
CI: Use actions/setup-python to cache pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-{{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
       - name: Install Dependencies
         run: |
           python3 -m pip install coverage -U pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
             dev-requirements.txt
       - name: Install Dependencies
         run: |
-          python3 -m pip install coverage -U pip
-          python3 -m pip install coverage -U wheel
-          python3 -m pip install coverage -U -r dev-requirements.txt
+          python3 -m pip install -U pip
+          python3 -m pip install -U wheel
+          python3 -m pip install -U -r dev-requirements.txt
         env:
           # TEMP for 3.11
           # https://github.com/aio-libs/aiohttp/issues/6600


### PR DESCRIPTION
https://github.com/actions/setup-python now has pip caching built-in: https://github.com/actions/setup-python#caching-packages-dependencies

So we don't an extra https://github.com/actions/cache step.

We also don't need to install Coverage.py explicitly, as we're using pytest-cov (via dev-dependencies.txt) that takes care of it.