### PR TITLE
Add tox config and build using CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           # https://github.com/aio-libs/yarl/issues/680
           YARL_NO_EXTENSIONS: 1
       - name: Run Tests
+        env:
+          # run against the current Python interpreter
+          TOXENV=python
         run: tox
       - uses: codecov/codecov-action@v2
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,9 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             dev-requirements.txt
-      - name: Install Dependencies
+      - name: Install tox
         run: |
-          python3 -m pip install -U pip
-          python3 -m pip install -U wheel
-          python3 -m pip install -U -r dev-requirements.txt
+          python -m pip install tox
         env:
           # TEMP for 3.11
           # https://github.com/aio-libs/aiohttp/issues/6600
@@ -38,7 +36,7 @@ jobs:
           # https://github.com/aio-libs/yarl/issues/680
           YARL_NO_EXTENSIONS: 1
       - name: Run Tests
-        run: pytest --cov --cov-report=term --cov-report=xml
+        run: tox
       - uses: codecov/codecov-action@v2
         if: always()
         with:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 testpaths = tests
-addopts = --cov --cov-report=term --cov-report=xml
+addopts = --cov --cov-report=html --cov-report=term --cov-report=xml
 # https://github.com/pytest-dev/pytest-asyncio#modes
 asyncio_mode = auto

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 testpaths = tests
+addopts = --cov --cov-report=term --cov-report=xml
 # https://github.com/pytest-dev/pytest-asyncio#modes
 asyncio_mode = auto

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+[tox]
+envlist = python
+minversion = 3.2
+# https://github.com/jaraco/skeleton/issues/6
+tox_pip_extensions_ext_venv_update = true
+toxworkdir={env:TOX_WORK_DIR:.tox}
+
+
+[testenv]
+deps =
+commands =
+	pytest {posargs}
+usedevelop = True
+extras = testing
+
+[testenv:docs]
+extras =
+	docs
+	testing
+changedir = docs
+commands =
+	python -m sphinx -W --keep-going . {toxinidir}/build/html
+
+[testenv:release]
+skip_install = True
+deps =
+	build
+	twine>=3
+	jaraco.develop>=7.1
+passenv =
+	TWINE_PASSWORD
+	GITHUB_TOKEN
+setenv =
+	TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
+commands =
+	python -c "import shutil; shutil.rmtree('dist', ignore_errors=True)"
+	python -m build
+	python -m twine upload dist/*
+	python -m jaraco.develop.create-github-release

--- a/tox.ini
+++ b/tox.ini
@@ -1,39 +1,11 @@
 [tox]
 envlist = python
-minversion = 3.2
-# https://github.com/jaraco/skeleton/issues/6
-tox_pip_extensions_ext_venv_update = true
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 
 [testenv]
-deps =
-commands =
-	pytest {posargs}
-usedevelop = True
-extras = testing
-
-[testenv:docs]
-extras =
-	docs
-	testing
-changedir = docs
-commands =
-	python -m sphinx -W --keep-going . {toxinidir}/build/html
-
-[testenv:release]
 skip_install = True
 deps =
-	build
-	twine>=3
-	jaraco.develop>=7.1
-passenv =
-	TWINE_PASSWORD
-	GITHUB_TOKEN
-setenv =
-	TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
+	-r dev-requirements.txt
 commands =
-	python -c "import shutil; shutil.rmtree('dist', ignore_errors=True)"
-	python -m build
-	python -m twine upload dist/*
-	python -m jaraco.develop.create-github-release
+	pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python
+envlist = py{311, 310, 39, 38}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 


### PR DESCRIPTION
Fixes #469.

- Add tox.ini from jaraco/skeleton
- Trim irrelevant details from tox.ini
- In CI, invoke tests with tox. Move pytest args to pytest config.
