### PR TITLE
Build against pre-releases then stable releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
+        python-version:
+        # Build on pre-releases until stable, then stable releases.
+        # actions/setup-python#213
+        - ~3.8.0-0
+        - ~3.9.0-0
+        - ~3.10.0-0
+        - ~3.11.0-0
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I use this technique in jaraco/skeleton (and derived projects) to reduce the number of commits necessary to adopt a Python version by 50% (by adopting each version during pre-release and then switching to stable once final is released). In https://github.com/actions/setup-python/issues/213, I've reported the issue and I'm hoping that soon, "N.NN" will be sufficient to have the same behavior without having to require adding '-dev' and removing it later.

Feel free to reject if the ugliness outweighs the benefit.