### PR TITLE
Set env vars in tox to build 3.11 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,6 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install tox
-        env:
-          # TEMP for 3.11
-          # https://github.com/aio-libs/aiohttp/issues/6600
-          AIOHTTP_NO_EXTENSIONS: 1
-          # https://github.com/aio-libs/frozenlist/issues/285
-          FROZENLIST_NO_EXTENSIONS: 1
-          # https://github.com/aio-libs/yarl/issues/680
-          YARL_NO_EXTENSIONS: 1
       - name: Run Tests
         env:
           # run against the current Python interpreter

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 envlist = py{311, 310, 39, 38}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
-
 [testenv]
+passenv =
+    FORCE_COLOR
 setenv =
     # TEMP for 3.11
     # https://github.com/aio-libs/aiohttp/issues/6600

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,14 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 
 
 [testenv]
+setenv =
+    # TEMP for 3.11
+    # https://github.com/aio-libs/aiohttp/issues/6600
+    AIOHTTP_NO_EXTENSIONS = 1
+    # https://github.com/aio-libs/frozenlist/issues/285
+    FROZENLIST_NO_EXTENSIONS = 1
+    # https://github.com/aio-libs/yarl/issues/680
+    YARL_NO_EXTENSIONS = 1
 skip_install = True
 deps =
 	-r dev-requirements.txt


### PR DESCRIPTION
After I pushed the tox changes (https://github.com/python/bedevere/pull/471, https://github.com/python/bedevere/pull/474) to my branch, it failed on Python 3.11:

* https://github.com/hugovk/bedevere/runs/6969338848?check_suite_focus=true

But it passed here:

* https://github.com/python/bedevere/actions/runs/2529801953

The problem is we are missing the env vars to temporarily fix the dependency build for 3.11. Let's move them out of the workflow and into tox.ini, so they're also available locally.

The reason it passed here was because there was still a pip cache from last time, whereas the cache had expired on my fork and it needed to build again from scratch.

Here's a passing run of this fix on my fork:

* https://github.com/hugovk/bedevere/actions/runs/2529924094

---

Also keep the colour output for pytest when run inside tox by passing in `FORCE_COLOR`.
