### PR TITLE
Auto add the ``skip news`` label to ``docs`` PRs

### DIFF
--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -8,8 +8,8 @@ TYPE_LABEL_PREFIX = "type"
 
 
 @enum.unique
-class Category(enum.Enum):
-    """Category of Pull Request."""
+class Labels(enum.Enum):
+    """Labels that can be applied to a Pull Request."""
 
     type_bug = f"{TYPE_LABEL_PREFIX}-bug"
     documentation = "docs"
@@ -19,7 +19,7 @@ class Category(enum.Enum):
     tests = "tests"
 
 
-async def add_category(gh, issue, category):
+async def add_label(gh, issue, category):
     """Apply this type label if there aren't any type labels on the PR."""
     if any(label.startswith("type") for label in util.labels(issue)):
         return
@@ -47,7 +47,7 @@ async def classify_by_filepaths(gh, pull_request, filenames):
         else:
             return
     if tests:
-        await add_category(gh, issue, Category.tests)
+        await add_label(gh, issue, Labels.tests)
     elif docs:
-        await add_category(gh, issue, Category.documentation)
+        await add_label(gh, issue, Labels.documentation)
     return

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -20,12 +20,12 @@ class Labels(enum.Enum):
     skip_news = "skip news"
 
 
-async def add_label(gh, issue, labels):
-    """Apply this type label if there aren't any type labels on the PR."""
-    if any(label.startswith("type") for label in util.labels(issue)):
-        return
-    label_names = [c.value for c in labels]
-    await gh.post(issue["labels_url"], data=label_names)
+async def add_labels(gh, issue, labels):
+    """Add the specified labels to the PR."""
+    current_labels = util.labels(issue)
+    label_names = [c.value for c in labels if c.value not in current_labels]
+    if label_names:
+        await gh.post(issue["labels_url"], data=label_names)
 
 
 async def classify_by_filepaths(gh, pull_request, filenames):
@@ -49,10 +49,10 @@ async def classify_by_filepaths(gh, pull_request, filenames):
         else:
             return
     if tests:
-        await add_label(gh, issue, [Labels.tests])
+        await add_labels(gh, issue, [Labels.tests])
     elif docs:
         if news:
-            await add_label(gh, issue, [Labels.docs])
+            await add_labels(gh, issue, [Labels.docs])
         else:
-            await add_label(gh, issue, [Labels.docs, Labels.skip_news])
+            await add_labels(gh, issue, [Labels.docs, Labels.skip_news])
     return

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -12,7 +12,7 @@ class Labels(enum.Enum):
     """Labels that can be applied to a Pull Request."""
 
     type_bug = f"{TYPE_LABEL_PREFIX}-bug"
-    documentation = "docs"
+    docs = "docs"
     type_feature = f"{TYPE_LABEL_PREFIX}-feature"
     performance = "performance"
     type_security = f"{TYPE_LABEL_PREFIX}-security"
@@ -49,5 +49,5 @@ async def classify_by_filepaths(gh, pull_request, filenames):
     if tests:
         await add_label(gh, issue, Labels.tests)
     elif docs:
-        await add_label(gh, issue, Labels.documentation)
+        await add_label(gh, issue, Labels.docs)
     return

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -19,11 +19,11 @@ class Labels(enum.Enum):
     tests = "tests"
 
 
-async def add_label(gh, issue, category):
+async def add_label(gh, issue, label):
     """Apply this type label if there aren't any type labels on the PR."""
     if any(label.startswith("type") for label in util.labels(issue)):
         return
-    await gh.post(issue["labels_url"], data=[category.value])
+    await gh.post(issue["labels_url"], data=[label.value])
 
 
 async def classify_by_filepaths(gh, pull_request, filenames):

--- a/bedevere/util.py
+++ b/bedevere/util.py
@@ -4,7 +4,6 @@ import sys
 
 import gidgethub
 
-
 DEFAULT_BODY = ""
 TAG_NAME = "gh-issue-number"
 NEWS_NEXT_DIR = "Misc/NEWS.d/next/"
@@ -88,7 +87,11 @@ async def files_for_PR(gh, pull_request):
 
 
 async def issue_for_PR(gh, pull_request):
-    """Get the issue data for a pull request."""
+    """Get the issue_url for a pull request.
+
+    The issue_url is the API endpoint for the given pull_request.
+    This terminology follows the official Github API and its documentation.
+    """
     return await gh.getitem(pull_request["issue_url"])
 
 
@@ -106,7 +109,11 @@ async def patch_body(gh, pull_request, issue_number):
     if not re.search(rf"(^|\b)(GH-|gh-|#){issue_number}\b", pull_request["body"]):
         return await gh.patch(
             pull_request["url"],
-            data={"body": BODY.format(body=pull_request["body"], issue_number=issue_number)},
+            data={
+                "body": BODY.format(
+                    body=pull_request["body"], issue_number=issue_number
+                )
+            },
         )
     return
 

--- a/bedevere/util.py
+++ b/bedevere/util.py
@@ -110,11 +110,7 @@ async def patch_body(gh, pull_request, issue_number):
     if not re.search(rf"(^|\b)(GH-|gh-|#){issue_number}\b", pull_request["body"]):
         return await gh.patch(
             pull_request["url"],
-            data={
-                "body": BODY.format(
-                    body=pull_request["body"], issue_number=issue_number
-                )
-            },
+            data={"body": BODY.format(body=pull_request["body"], issue_number=issue_number)},
         )
     return
 

--- a/bedevere/util.py
+++ b/bedevere/util.py
@@ -88,11 +88,8 @@ async def files_for_PR(gh, pull_request):
 
 
 async def issue_for_PR(gh, pull_request):
-    """Get the issue_url for a pull request.
-
-    The issue_url is the API endpoint for the given pull_request.
-    This terminology follows the official Github API and its documentation.
-    """
+    """Return a dict with data about the given PR."""
+    # "issue_url" is the API endpoint for the given pull_request (despite the name)
     return await gh.getitem(pull_request["issue_url"])
 
 

--- a/bedevere/util.py
+++ b/bedevere/util.py
@@ -4,6 +4,7 @@ import sys
 
 import gidgethub
 
+
 DEFAULT_BODY = ""
 TAG_NAME = "gh-issue-number"
 NEWS_NEXT_DIR = "Misc/NEWS.d/next/"

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -4,7 +4,7 @@ from gidgethub import sansio
 
 from bedevere import filepaths
 
-from bedevere.prtype import Category
+from bedevere.prtype import Labels
 
 from .test_news import check_n_pop_nonews_events
 
@@ -88,7 +88,7 @@ async def test_docs_only(author_association):
     check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.documentation.value]
+    assert gh.post_data[0] == [Labels.documentation.value]
 
 
 @pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])
@@ -117,7 +117,7 @@ async def test_tests_only(author_association):
     check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_docs_and_tests():
@@ -145,7 +145,7 @@ async def test_docs_and_tests():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'success'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == [Category.tests.value]
+    assert gh.post_data[1] == [Labels.tests.value]
 
 
 async def test_news_and_tests():
@@ -174,7 +174,7 @@ async def test_news_and_tests():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'success'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == [Category.tests.value]
+    assert gh.post_data[1] == [Labels.tests.value]
 
 
 async def test_synchronize():

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -88,7 +88,7 @@ async def test_docs_only(author_association):
     check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.docs.value]
+    assert gh.post_data[0] == [Labels.docs.value, Labels.skip_news.value]
 
 
 @pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -88,7 +88,7 @@ async def test_docs_only(author_association):
     check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.documentation.value]
+    assert gh.post_data[0] == [Labels.docs.value]
 
 
 @pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -2,7 +2,7 @@ import pytest
 
 from gidgethub import sansio
 
-from bedevere import news, filepaths
+from bedevere import filepaths
 
 from bedevere.prtype import Category
 

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -169,7 +169,10 @@ async def test_leave_existing_type_labels():
     await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     # Only creates type-tests label.
-    assert len(gh.post_url) == 0
+    assert len(gh.post_url) == 1
+    assert gh.post_url[0] == "https://api.github.com/some/label"
+    assert gh.post_data[0] == [Labels.tests.value]
+
 
 
 async def test_news_and_tests():

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -1,5 +1,5 @@
 from bedevere import prtype
-from bedevere.prtype import Category
+from bedevere.prtype import Labels
 
 
 class FakeGH:
@@ -85,7 +85,7 @@ async def test_docs_no_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.documentation.value]
+    assert gh.post_data[0] == [Labels.documentation.value]
 
 
 async def test_docs_and_news():
@@ -106,7 +106,7 @@ async def test_docs_and_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.documentation.value]
+    assert gh.post_data[0] == [Labels.documentation.value]
 
 
 async def test_tests_only():
@@ -127,7 +127,7 @@ async def test_tests_only():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_docs_and_tests():
@@ -149,7 +149,7 @@ async def test_docs_and_tests():
     # Only creates type-tests label.
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_leave_existing_type_labels():
@@ -191,7 +191,7 @@ async def test_news_and_tests():
     # Creates type-tests label.
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_other_files():

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -62,7 +62,7 @@ async def test_news_only():
     }
     await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    # News only .rst does not add a type-documentation label.
+    # News only .rst does not add a type-docs label.
     assert len(gh.post_url) == 0
     assert len(gh.post_data) == 0
 
@@ -85,7 +85,7 @@ async def test_docs_no_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.documentation.value]
+    assert gh.post_data[0] == [Labels.docs.value]
 
 
 async def test_docs_and_news():
@@ -106,7 +106,7 @@ async def test_docs_and_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.documentation.value]
+    assert gh.post_data[0] == [Labels.docs.value]
 
 
 async def test_tests_only():

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -85,7 +85,7 @@ async def test_docs_no_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.docs.value]
+    assert gh.post_data[0] == [Labels.docs.value, Labels.skip_news.value]
 
 
 async def test_docs_and_news():

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -62,7 +62,7 @@ async def test_news_only():
     }
     await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    # News only .rst does not add a type-docs label.
+    # News only .rst does not add a docs label.
     assert len(gh.post_url) == 0
     assert len(gh.post_data) == 0
 


### PR DESCRIPTION
Closes #457.
Also closes https://github.com/python/core-workflow/issues/363.

Follow up can also tackle https://github.com/python/core-workflow/issues/421 but I decided to keep this small since the feedback on https://github.com/python/core-workflow/issues/363 shows that the consensus reached in #457 is not shared by everybody.

Two edge cases which were not considered in the original issue but on which somebody should probably take a decision:
1) What if the PR already has a news item? Currently it still adds the `skip news` label as shown by `test_docs_and_news`.
2) Should the `skip news` label also be applied if the PR has a test? Currently I thought I would not do so as to not make this change too controversial, but I'm happy to change this obviously.

Let me know what you think!