### PR TITLE
Refactor ``Category`` to be ``Labels``

### DIFF
--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -8,8 +8,8 @@ TYPE_LABEL_PREFIX = "type"
 
 
 @enum.unique
-class Category(enum.Enum):
-    """Category of Pull Request."""
+class Labels(enum.Enum):
+    """Labels that can be applied to a Pull Request."""
 
     type_bug = f"{TYPE_LABEL_PREFIX}-bug"
     documentation = "docs"
@@ -19,7 +19,7 @@ class Category(enum.Enum):
     tests = "tests"
 
 
-async def add_category(gh, issue, category):
+async def add_label(gh, issue, category):
     """Apply this type label if there aren't any type labels on the PR."""
     if any(label.startswith("type") for label in util.labels(issue)):
         return
@@ -47,7 +47,7 @@ async def classify_by_filepaths(gh, pull_request, filenames):
         else:
             return
     if tests:
-        await add_category(gh, issue, Category.tests)
+        await add_label(gh, issue, Labels.tests)
     elif docs:
-        await add_category(gh, issue, Category.documentation)
+        await add_label(gh, issue, Labels.documentation)
     return

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -12,7 +12,7 @@ class Labels(enum.Enum):
     """Labels that can be applied to a Pull Request."""
 
     type_bug = f"{TYPE_LABEL_PREFIX}-bug"
-    documentation = "docs"
+    docs = "docs"
     type_feature = f"{TYPE_LABEL_PREFIX}-feature"
     performance = "performance"
     type_security = f"{TYPE_LABEL_PREFIX}-security"
@@ -49,5 +49,5 @@ async def classify_by_filepaths(gh, pull_request, filenames):
     if tests:
         await add_label(gh, issue, Labels.tests)
     elif docs:
-        await add_label(gh, issue, Labels.documentation)
+        await add_label(gh, issue, Labels.docs)
     return

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -19,11 +19,11 @@ class Labels(enum.Enum):
     tests = "tests"
 
 
-async def add_label(gh, issue, category):
+async def add_label(gh, issue, label):
     """Apply this type label if there aren't any type labels on the PR."""
     if any(label.startswith("type") for label in util.labels(issue)):
         return
-    await gh.post(issue["labels_url"], data=[category.value])
+    await gh.post(issue["labels_url"], data=[label.value])
 
 
 async def classify_by_filepaths(gh, pull_request, filenames):

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -4,7 +4,7 @@ from gidgethub import sansio
 
 from bedevere import filepaths
 
-from bedevere.prtype import Category
+from bedevere.prtype import Labels
 
 from .test_news import check_n_pop_nonews_events
 
@@ -88,7 +88,7 @@ async def test_docs_only(author_association):
     check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.documentation.value]
+    assert gh.post_data[0] == [Labels.documentation.value]
 
 
 @pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])
@@ -117,7 +117,7 @@ async def test_tests_only(author_association):
     check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_docs_and_tests():
@@ -145,7 +145,7 @@ async def test_docs_and_tests():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'success'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == [Category.tests.value]
+    assert gh.post_data[1] == [Labels.tests.value]
 
 
 async def test_news_and_tests():
@@ -174,7 +174,7 @@ async def test_news_and_tests():
     assert gh.post_url[0] == 'https://api.github.com/some/status'
     assert gh.post_data[0]['state'] == 'success'
     assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == [Category.tests.value]
+    assert gh.post_data[1] == [Labels.tests.value]
 
 
 async def test_synchronize():

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -88,7 +88,7 @@ async def test_docs_only(author_association):
     check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.documentation.value]
+    assert gh.post_data[0] == [Labels.docs.value]
 
 
 @pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -2,7 +2,7 @@ import pytest
 
 from gidgethub import sansio
 
-from bedevere import news, filepaths
+from bedevere import filepaths
 
 from bedevere.prtype import Category
 

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -1,5 +1,5 @@
 from bedevere import prtype
-from bedevere.prtype import Category
+from bedevere.prtype import Labels
 
 
 class FakeGH:
@@ -85,7 +85,7 @@ async def test_docs_no_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.documentation.value]
+    assert gh.post_data[0] == [Labels.documentation.value]
 
 
 async def test_docs_and_news():
@@ -106,7 +106,7 @@ async def test_docs_and_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.documentation.value]
+    assert gh.post_data[0] == [Labels.documentation.value]
 
 
 async def test_tests_only():
@@ -127,7 +127,7 @@ async def test_tests_only():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_docs_and_tests():
@@ -149,7 +149,7 @@ async def test_docs_and_tests():
     # Only creates type-tests label.
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_leave_existing_type_labels():
@@ -191,7 +191,7 @@ async def test_news_and_tests():
     # Creates type-tests label.
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Category.tests.value]
+    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_other_files():

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -62,7 +62,7 @@ async def test_news_only():
     }
     await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    # News only .rst does not add a type-documentation label.
+    # News only .rst does not add a type-docs label.
     assert len(gh.post_url) == 0
     assert len(gh.post_data) == 0
 
@@ -85,7 +85,7 @@ async def test_docs_no_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.documentation.value]
+    assert gh.post_data[0] == [Labels.docs.value]
 
 
 async def test_docs_and_news():
@@ -106,7 +106,7 @@ async def test_docs_and_news():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.documentation.value]
+    assert gh.post_data[0] == [Labels.docs.value]
 
 
 async def test_tests_only():

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -62,7 +62,7 @@ async def test_news_only():
     }
     await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    # News only .rst does not add a type-docs label.
+    # News only .rst does not add a docs label.
     assert len(gh.post_url) == 0
     assert len(gh.post_data) == 0
 


### PR DESCRIPTION
Refactor as requested by @ezio-melotti in https://github.com/python/bedevere/pull/485#discussion_r916157446.

Also couldn't help but notice the unused import so I removed it in a separate commit. If that's undesired I'll revert that change obviously!