### PR TITLE
Label a PR before posting the blurb help comment

### DIFF
--- a/bedevere/filepaths.py
+++ b/bedevere/filepaths.py
@@ -16,7 +16,9 @@ async def check_file_paths(event, gh, *args, **kwargs):
     pull_request = event.data['pull_request']
     files = await util.files_for_PR(gh, pull_request)
     filenames = [file['file_name'] for file in files]
-    await news.check_news(gh, pull_request, files)
     if event.data['action'] == 'opened':
-        await prtype.classify_by_filepaths(gh, pull_request, filenames)
-
+        labels = await prtype.classify_by_filepaths(gh, pull_request, filenames)
+        if prtype.Labels.skip_news not in labels:
+            await news.check_news(gh, pull_request, files)
+    else:
+        await news.check_news(gh, pull_request, files)

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -36,6 +36,7 @@ async def classify_by_filepaths(gh, pull_request, filenames):
 
     The routing is handled by the filepaths module.
     """
+    pr_labels = []
     issue = await util.issue_for_PR(gh, pull_request)
     news = docs = tests = False
     for filename in filenames:
@@ -47,12 +48,13 @@ async def classify_by_filepaths(gh, pull_request, filenames):
         elif filepath.name.startswith('test_'):
             tests = True
         else:
-            return
+            return pr_labels
     if tests:
-        await add_labels(gh, issue, [Labels.tests])
+        pr_labels = [Labels.tests]
     elif docs:
         if news:
-            await add_labels(gh, issue, [Labels.docs])
+            pr_labels = [Labels.docs]
         else:
-            await add_labels(gh, issue, [Labels.docs, Labels.skip_news])
-    return
+            pr_labels = [Labels.docs, Labels.skip_news]
+    await add_labels(gh, issue, pr_labels)
+    return pr_labels

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -85,7 +85,6 @@ async def test_docs_only(author_association):
     await filepaths.router.dispatch(event, gh)
     assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    check_n_pop_nonews_events(gh, author_association == 'NONE')
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == 'https://api.github.com/some/label'
     assert gh.post_data[0] == [Labels.docs.value, Labels.skip_news.value]
@@ -114,10 +113,10 @@ async def test_tests_only(author_association):
     await filepaths.router.dispatch(event, gh)
     assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    assert len(gh.post_url) == 3 if author_association == 'NONE' else 2
+    assert gh.post_url.pop(0) == 'https://api.github.com/some/label'
+    assert gh.post_data.pop(0) == [Labels.tests.value]
     check_n_pop_nonews_events(gh, author_association == 'NONE')
-    assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
-    assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_docs_and_tests():
@@ -142,10 +141,10 @@ async def test_docs_and_tests():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     # Only creates type-tests label.
     assert len(gh.post_url) == 2
-    assert gh.post_url[0] == 'https://api.github.com/some/status'
-    assert gh.post_data[0]['state'] == 'success'
-    assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == [Labels.tests.value]
+    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_data[0] == [Labels.tests.value]
+    assert gh.post_url[1] == 'https://api.github.com/some/status'
+    assert gh.post_data[1]['state'] == 'success'
 
 
 async def test_news_and_tests():
@@ -171,10 +170,10 @@ async def test_news_and_tests():
     assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
     # Only creates type-tests label.
     assert len(gh.post_url) == 2
-    assert gh.post_url[0] == 'https://api.github.com/some/status'
-    assert gh.post_data[0]['state'] == 'success'
-    assert gh.post_url[1] == 'https://api.github.com/some/label'
-    assert gh.post_data[1] == [Labels.tests.value]
+    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_data[0] == [Labels.tests.value]
+    assert gh.post_url[1] == 'https://api.github.com/some/status'
+    assert gh.post_data[1]['state'] == 'success'
 
 
 async def test_synchronize():


### PR DESCRIPTION
Follow up to https://github.com/python/bedevere/pull/485

https://github.com/python/cpython/pull/94828 shows the previous PR works: changes to documentation are correctly labeled as `skip news`.
However, we're doing the check for the `blurb_it` help comment before we do the labeling.

This makes it so that we don't check whether we need to post that comment if we are going to label a PR as skip news.

/CC @ezio-melotti 