### PR TITLE
Add the labels flowchart to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,34 @@ Labels PRs for documentation as `type-documentation`
 - ### Copies main labels to backport
 Copies labels from main PRs to backport PRs
 
+## PR State Machine
+
+This diagram represent the state machine for pull requests, and the labels
+applied by Bedevere.
+
+The colors represent who can make a state change or who is currently
+blocking the PR from moving forward:
+* Yellow: the PR creator
+* Green: core developers
+* Blue: anyone
+
+```mermaid
+flowchart TD
+    A([New PR]):::creator
+    A -- by contributor --> B[Awaiting review]:::anyone
+    A -- by core dev --> C[Awaiting core review]:::coredev
+    B & C -- new review by\nanother contributor --> C
+    C & B & E  -- new core review\nrequests changes --> D[Awaiting changes]:::creator
+    D -- changes by contributor --> E[Awaiting change review]:::coredev
+    C & E & B -- new core review\napproves ---> F[Awaiting merge]:::coredev
+classDef creator stroke:#CC0;
+classDef anyone stroke:#00C;
+classDef coredev stroke:#0C0;
+linkStyle 0,1,7 stroke:#CC0,color:auto;
+linkStyle 2,3 stroke:#00C,color:auto;
+linkStyle 4,5,6,8,9,10 stroke:#0C0,color:auto;
+```
+
 ## *Aside*: where does the name come from?
 Since this bot is about identifying pull requests that need changes,
 it seemed fitting to name it after Sir Bedevere who knew

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ blocking the PR from moving forward:
 * Green: core developers
 * Blue: anyone
 
+<!--
+  Changes to the labels in this flowchart should be reflected
+  in the devguide: https://devguide.python.org/triage/labels/
+-->
+
 ```mermaid
 flowchart TD
     A([New PR]):::creator
@@ -48,6 +53,7 @@ flowchart TD
 classDef creator stroke:#CC0;
 classDef anyone stroke:#00C;
 classDef coredev stroke:#0C0;
+classDef triager stroke:#C0C;
 linkStyle 0,1,7 stroke:#CC0,color:auto;
 linkStyle 2,3 stroke:#00C,color:auto;
 linkStyle 4,5,6,8,9,10 stroke:#0C0,color:auto;

--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -1,41 +1,11 @@
 """Label a pull request based on what its waiting on."""
 
-# The following is the state machine for the flow of a PR
-# (written as a DOT file; you can use Graphviz or
-# http://www.webgraphviz.com/ to view the graph):
-"""
-digraph "PR stages" {
-  /* Colours represent who can make a state change or who is currently
-     blocking the PR from moving forward.
-
-     Blue: Anyone
-     Orange: PR creator
-     Green: Core developer
-     Purple: Triager Actions
-  */
-
-  "New PR" [color=orange]
-  "Awaiting review" [shape=box, color=blue]
-  "Awaiting core review" [shape=box, color=green]
-  "Awaiting changes" [shape=box, color=orange]
-  "Awaiting change review" [shape=box, color=green]
-  "Awaiting merge" [shape=box, color=green]
-
-  "New PR" -> "Awaiting review" [label="New PR by a contributor", color=orange]
-  "Awaiting review" -> "Awaiting core review" [label="New review by another contributor", color=blue]
-  "Awaiting core review" -> "Awaiting core review" [label="New review by another contributor", color=blue]
-  "Awaiting core review" -> "Awaiting changes" [label="New core review requests changes", color=green]
-  "Awaiting changes" -> "Awaiting change review" [label="Changes are done by contributor\nBedevere requests review from core-dev", color=orange]
-  "Awaiting change review" -> "Awaiting changes" [label="New core review requests changes", color=green]
-  "Awaiting change review" -> "Awaiting merge" [label="New core review approves", color=green]
-
-  "Awaiting review" -> "Awaiting merge" [label="New core review approves", color=green]
-  "Awaiting review" -> "Awaiting changes" [label="New core review requests changes", color=green]
-  "Awaiting core review" -> "Awaiting merge" [label="New core review approves", color=green]
-
-  "New PR" -> "Awaiting core review" [label="New PR by core devs", color=green]
-}
-"""
+# The state machine for the flow of a PR is currently
+# documented with a Mermaid graph in the README.
+# The graph replaces a previous version (written as
+# a DOT file) that was included here.
+# 
+# Changes to this file should be reflected in the README.
 
 import datetime
 import enum

--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -4,7 +4,7 @@
 # documented with a Mermaid graph in the README.
 # The graph replaces a previous version (written as
 # a DOT file) that was included here.
-# 
+#
 # Changes to this file should be reflected in the README.
 
 import datetime


### PR DESCRIPTION
This PR adds a flowchart that describe the PR state machine to the `README`.  

Related issues:
* The flowchart will be linked in https://github.com/python/devguide/pull/930
* The idea was brought up in https://github.com/python/devguide/issues/868

The flowchart is described in
https://github.com/python/bedevere/blob/428290e46a9507c7810614e15294163d2b4f9eb0/bedevere/stage.py#L3-L38
which renders to

![image](https://user-images.githubusercontent.com/25624924/183272934-b26ab238-f04c-429a-ba79-a0cc88c540d6.png)


For the implementation I used mermaid, which is supported natively by GitHub-flavored Markdown.  The new flowchart renders to:
```mermaid
flowchart TD
    A([New PR]):::creator
    A -- by contributor --> B[Awaiting review]:::anyone
    A -- by core dev --> C[Awaiting core review]:::coredev
    B & C -- new review by\nanother contributor --> C
    C & B & E  -- new core review\nrequests changes --> D[Awaiting changes]:::creator
    D -- changes by contributor --> E[Awaiting change review]:::coredev
    C & E & B -- new core review\napproves ---> F[Awaiting merge]:::coredev
classDef creator stroke:#CC0;
classDef anyone stroke:#00C;
classDef coredev stroke:#0C0;
linkStyle 0,1,7 stroke:#CC0,color:auto;
linkStyle 2,3 stroke:#00C,color:auto;
linkStyle 4,5,6,8,9,10 stroke:#0C0,color:auto;
```
<details>
<summary>Click to see a screenshot of the flowchart (using the dark theme)</summary>

![image](https://user-images.githubusercontent.com/25624924/183272965-f89bea3e-3474-4758-917e-dafa07b7bc5f.png)
</details>

