### PR TITLE
Remove Python 3.11 test workarounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           # run against the current Python interpreter
           TOXENV: python
         run: tox
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.1
+aiohttp==3.8.3
 appdirs==1.4.4
 async-timeout==4.0.2
 cachetools==5.2.0
@@ -10,5 +10,5 @@ py==1.11.0
 pyparsing==3.0.9
 six==1.16.0
 uritemplate==4.1.1
-yarl==1.7.2
+yarl==1.8.1
 sentry-sdk==1.9.7

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,6 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 [testenv]
 passenv =
     FORCE_COLOR
-setenv =
-    # TEMP for 3.11
-    # https://github.com/aio-libs/aiohttp/issues/6600
-    AIOHTTP_NO_EXTENSIONS = 1
-    # https://github.com/aio-libs/frozenlist/issues/285
-    FROZENLIST_NO_EXTENSIONS = 1
-    # https://github.com/aio-libs/yarl/issues/680
-    YARL_NO_EXTENSIONS = 1
 skip_install = True
 deps =
 	-r dev-requirements.txt


### PR DESCRIPTION
Bump dependencies now they support Python 3.11 and remove the workarounds.