### PR TITLE
Use actual precise Python version @ coverage flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        id: python-install
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -37,4 +39,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          flags: Python_${{ matrix.python-version }}
+          flags: Python_${{ steps.python-install.outputs.python-version }}


### PR DESCRIPTION
The matrix factor for the Python version is imprecise and doesn't always contain characters suitable for Codecov flags. `actions/setup-python@v4` now provides an output specifying exactly what's been installed based on the request. This value is perfect for use in flags. This patch implements just that.