### PR TITLE
Add PR Links as List Items to Issues

### DIFF
--- a/bedevere/util.py
+++ b/bedevere/util.py
@@ -27,18 +27,16 @@ ISSUE_BODY_OPENING_TAG = f'<!-- {ISSUE_BODY_TAG_NAME} -->'
 ISSUE_BODY_CLOSING_TAG = f'<!-- /{ISSUE_BODY_TAG_NAME} -->'
 ISSUE_BODY_TASK_LIST_TEMPLATE = f"""\n
 {ISSUE_BODY_OPENING_TAG}
-```[tasklist]
 ### Linked PRs
-- [ ] gh-{{pr_number}}
-```
+* gh-{{pr_number}}
 {ISSUE_BODY_CLOSING_TAG}
 """
 
 # Regex pattern to search for tasklist in the issue body
 ISSUE_BODY_TASK_LIST_PATTERN = re.compile(
-    rf"(?P<start>{ISSUE_BODY_OPENING_TAG}\r?\n```\[tasklist\])"
+    rf"(?P<start>{ISSUE_BODY_OPENING_TAG})"
     rf"(?P<tasks>.*?)"
-    rf"(?P<end>```\r?\n{ISSUE_BODY_CLOSING_TAG})",
+    rf"(?P<end>{ISSUE_BODY_CLOSING_TAG})",
     flags=re.DOTALL
 )
 
@@ -151,8 +149,9 @@ def build_issue_body(pr_number: int, body: str) -> str:
 
     # If the body already contains a tasklist, only append the new PR to the list
     return ISSUE_BODY_TASK_LIST_PATTERN.sub(
-        fr"\g<start>\g<tasks>- [ ] gh-{pr_number}\n\g<end>",
-        body
+        fr"\g<start>\g<tasks>* gh-{pr_number}\n\g<end>",
+        body,
+        count=1,
     )
 
 

--- a/tests/test_gh_issue.py
+++ b/tests/test_gh_issue.py
@@ -188,9 +188,9 @@ async def test_set_status_success_issue_found_on_gh(action, monkeypatch, issue_n
     assert len(gh.patch_data) > 0
     assert f"<!-- gh-issue-number: gh-{issue_number} -->" in gh.patch_data[0]["body"]
     assert (
-        "\n\n<!-- gh-linked-prs -->\n```[tasklist]\n"
-        f"### Linked PRs\n- [ ] gh-{issue_number}\n"
-        "```\n<!-- /gh-linked-prs -->\n"
+        "\n\n<!-- gh-linked-prs -->\n"
+        f"### Linked PRs\n* gh-{issue_number}\n"
+        "<!-- /gh-linked-prs -->\n"
     ) in gh.patch_data[1]["body"]
     assert len(gh.patch_url) == 2
     assert gh.patch_url[0] == data["pull_request"]["url"]
@@ -227,9 +227,9 @@ async def test_set_status_success_issue_found_on_gh_ignore_case(action, monkeypa
     assert len(gh.patch_data) > 0
     assert f"<!-- gh-issue-number: gh-{issue_number} -->" in gh.patch_data[0]["body"]
     assert (
-        "\n\n<!-- gh-linked-prs -->\n```[tasklist]\n"
-        f"### Linked PRs\n- [ ] gh-{issue_number}\n"
-        "```\n<!-- /gh-linked-prs -->\n"
+        "\n\n<!-- gh-linked-prs -->\n"
+        f"### Linked PRs\n* gh-{issue_number}\n"
+        "<!-- /gh-linked-prs -->\n"
     ) in gh.patch_data[1]["body"]
     assert len(gh.patch_url) == 2
     assert gh.patch_url[0] == data["pull_request"]["url"]
@@ -352,9 +352,9 @@ async def test_no_body_when_edit_title(monkeypatch, issue_number):
     assert len(gh.patch_data) > 0
     assert f"<!-- gh-issue-number: gh-{issue_number} -->" in gh.patch_data[0]["body"]
     assert (
-        "\n\n<!-- gh-linked-prs -->\n```[tasklist]\n"
-        f"### Linked PRs\n- [ ] gh-{issue_number}\n"
-        "```\n<!-- /gh-linked-prs -->\n"
+        "\n\n<!-- gh-linked-prs -->\n"
+        f"### Linked PRs\n* gh-{issue_number}\n"
+        "<!-- /gh-linked-prs -->\n"
     ) in gh.patch_data[1]["body"]
     assert len(gh.patch_url) == 2
     assert gh.patch_url[0] == data["pull_request"]["url"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -247,24 +247,24 @@ async def test_patch_body_adds_pr_if_not_present():
         await util.patch_body(gh, util.ISSUE, vals, 1234)
         data = {
             "body": (
-                "\n\n<!-- gh-linked-prs -->\n```[tasklist]\n"
-                "### Linked PRs\n- [ ] gh-1234\n"
-                "```\n<!-- /gh-linked-prs -->\n"
+                "\n\n<!-- gh-linked-prs -->\n"
+                "### Linked PRs\n* gh-1234\n"
+                "<!-- /gh-linked-prs -->\n"
             )
         }
         mock.assert_called_once_with("https://fake.com", data=data)
     with patch.object(gh, "patch") as mock:
         vals["body"] = (
-            "\n\n<!-- gh-linked-prs -->\n```[tasklist]\n"
-            "### Linked PRs\n- [ ] gh-1234\n"
-            "```\n<!-- /gh-linked-prs -->\n"
+            "\n\n<!-- gh-linked-prs -->\n"
+            "### Linked PRs\n* gh-1234\n"
+            "<!-- /gh-linked-prs -->\n"
         )
         await util.patch_body(gh, util.ISSUE, vals, 54321)
         data = {
             "body": (
-                "\n\n<!-- gh-linked-prs -->\n```[tasklist]\n"
-                "### Linked PRs\n- [ ] gh-1234\n- [ ] gh-54321\n"
-                "```\n<!-- /gh-linked-prs -->\n"
+                "\n\n<!-- gh-linked-prs -->\n"
+                "### Linked PRs\n* gh-1234\n* gh-54321\n"
+                "<!-- /gh-linked-prs -->\n"
             )
         }
         mock.assert_called_once_with("https://fake.com", data=data)


### PR DESCRIPTION
Follow up of my conversation with @ezio-melotti.

> Looks like this is not working for multiple PRs (https://github.com/python/cpython/issues/96192). After some investigation I found that `tasklists` doesn't just render the new UI, it also re-writes the Issue body.
> 
> **Example:**
> 
> ```markdown
> <!-- gh-linked-prs -->
> 
> https://github.com/python/cpython/issues/96192#tasklist-block-8fd60492-131e-4b4a-abab-06800aa4bb11
> 
> <!-- /gh-linked-prs -->
> 
> 
> <!-- gh-linked-prs -->
> 
> https://github.com/python/cpython/issues/96192#tasklist-block-ea9583fe-18a8-47ee-aec9-08a62427146b
> 
> <!-- /gh-linked-prs -->
> ```
> 
> I found this after I inspected the API response for https://github.com/python/cpython/issues/96192 (https://api.github.com/repos/python/cpython/issues/96192). This did not happen for the repositories I tested this PR on because it did not have this feature enabled.
> 
> This re-write causes multiple issues for us:
> 
> 1. **Important** As you can see from the API response above the re-write even removes the reference to the linked PR (`gh-{pr-number}`). This causes the bot to add the same PR multiple times to the same issue (https://github.com/python/cpython/issues/96192) and we have no way to check what PR was added before.
> 2. The RegEx does not match and we can not be sure if the re-write behavior will remain after this feature out of beta. (All the other type of rendering features does not re-write issue body)
> 
> I would suggest switching to `checklists` at least for now until `tasklists` are out of beta. As I do not have access to any repository with this feature enabled I was not able to investigate any further.
> 
 _Originally posted by @saadmk11 in https://github.com/python/bedevere/issues/518#issuecomment-1313219344_      

> > In that case, let's just switch to checklists for now.
> 
> Seems like auto marking a checklist items as completed (e.g: `- [x] gh-170`) when a PR is merged does not work, It only works if the checklist item is a GitHub Issues. @ezio-melotti Should we still proceed with this?
> 
 _Originally posted by @saadmk11 in https://github.com/python/bedevere/issues/518#issuecomment-1314965358_

      

> > Seems like auto marking a checklist items as completed (e.g: - [x] gh-170) when a PR is merged does not work

> If that's the case (i.e. merging a PR doesn't mark it as completed in the checklist), then there is no advantage in using checklists over plain lists.  The difference between checklists and plain lists is that the checklist shows the number of "tasks" at the top of the issue (as `(1 of 3 tasks)`) and that the PR will show up as `Tracked in #XXX`, however the former is useless if merged PRs are not marked as completed, and the latter is already covered by bedevere adding the issue link to each PR.
> 
> IOW, it's probably better to go back to plain lists for the time being.

_Originally posted by @ezio-melotti in https://github.com/python/bedevere/issues/518#issuecomment-1315458371_
      
**Related:** 
- https://github.com/python/bedevere/pull/518
- https://github.com/python/bedevere/issues/517