### PR TITLE
Temporarily pin to 3.12.0a4 pending dependency support for a5+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        # TODO replace 3.12.0-alpha.4 with 3.12-dev when
+        # aiohttp, frozenlist and yarl support alpha 5+
+        # https://github.com/python/blurb_it/pull/330#issuecomment-1449496275
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-alpha.4"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Similar to https://github.com/python/blurb_it/pull/331.

Let's pin to alpha 4 to the CI green and at least have some level 3.12 testing.

Upstream issues:

* [ ] aiohttp https://github.com/aio-libs/aiohttp/issues/7229
* [ ] frozenlist https://github.com/aio-libs/frozenlist/issues/433
* [ ] yarl https://github.com/aio-libs/yarl/issues/829

See also notes at https://github.com/python/blurb_it/pull/330#issuecomment-1449496275.