### PR TITLE
Remove unneeded codepath

### DIFF
--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -120,9 +120,6 @@ async def validate_maintenance_branch_pr(event, gh, *args, **kwargs):
 async def maintenance_branch_created(event, gh, *args, **kwargs):
     """Create the `needs backport label` when the maintenance branch is created.
 
-    Also post a reminder to add the maintenance branch to the list of
-    `ALLOWED_BRANCHES` in CPython-emailer-webhook.
-
     If a maintenance branch was created (e.g.: 3.9, or 4.0),
     automatically create the `needs backport to ` label.
 

--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -135,15 +135,3 @@ async def maintenance_branch_created(event, gh, *args, **kwargs):
             "/repos/python/cpython/labels",
             data={"name": f"needs backport to {branch_name}", "color": "#c2e0c6"},
         )
-
-        await gh.post(
-            "/repos/berkerpeksag/cpython-emailer-webhook/issues",
-            data={
-                "title": f"Please add {branch_name} to ALLOWED_BRANCHES",
-                "body": (
-                    f"A new CPython maintenance branch `{branch_name}` has just been created.",
-                    "\nThis is a reminder to add `{branch_name}` to the list of `ALLOWED_BRANCHES`",
-                    "\nhttps://github.com/berkerpeksag/cpython-emailer-webhook/blob/e164cb9a6735d56012a4e557fd67dd7715c16d7b/mailer.py#L15",
-                ),
-            },
-        )

--- a/tests/test_backport.py
+++ b/tests/test_backport.py
@@ -454,10 +454,6 @@ async def test_maintenance_branch_created(ref):
     assert label_creation_post[0] == "https://api.github.com/repos/python/cpython/labels"
     assert label_creation_post[1] == {'name': f"needs backport to {ref}", 'color': '#c2e0c6'}
 
-    issue_creation_post = gh.post_[1]
-    assert issue_creation_post[0] == "https://api.github.com/repos/berkerpeksag/cpython-emailer-webhook/issues"
-    assert issue_creation_post[1]['title'] == f"Please add {ref} to ALLOWED_BRANCHES"
-
 
 @pytest.mark.parametrize('ref', ['backport-3.9', 'test', 'Mariatta-patch-1'])
 async def test_other_branch_created(ref):


### PR DESCRIPTION
No longer need to update the `ALLOWED_BRANCHES` list in the CPython emailer webhook