### PR TITLE
Remove codecov dependency; skip running CI on 3.12 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        # TODO replace 3.12.0-alpha.4 with 3.12-dev when
+        # TODO add 3.12.0-dev when
         # aiohttp, frozenlist and yarl support alpha 5+
         # https://github.com/python/blurb_it/pull/330#issuecomment-1449496275
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-alpha.4"]
+        # https://github.com/python/bedevere/pull/547#issuecomment-1529153851
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,3 @@ pytest==7.2.2
 pytest-asyncio==0.21.0
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0
-codecov==2.1.12


### PR DESCRIPTION
The `codecov` package is no longer installable, meaning that `pip install dev-requirements.txt` for this repo now always fails. It also doesn't seem to be necessary to install it in CI; we don't use it for anything as far as I can see, and the codecov action doesn't require it.