### PR TITLE
CI: set `fail-fast` to False

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         # TODO add 3.12-dev when
         # aiohttp, frozenlist and yarl support alpha 5+
         # https://github.com/python/blurb_it/pull/330#issuecomment-1449496275
         # https://github.com/python/bedevere/pull/547#issuecomment-1529153851
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        # TODO add 3.12.0-dev when
+        # TODO add 3.12-dev when
         # aiohttp, frozenlist and yarl support alpha 5+
         # https://github.com/python/blurb_it/pull/330#issuecomment-1449496275
         # https://github.com/python/bedevere/pull/547#issuecomment-1529153851
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
With `fail-fast` set to True (the default), all running jobs in the matrix are cancelled as soon as a single one fails. This makes it hard to see exactly which Python versions a PR is failing on, if there are failures, because the CI just becomes a sea of red, even if the PR is only failing on a single Python version.