### PR TITLE
CI: Specify tox 'py' environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
         run: |
           python -m pip install tox
       - name: Run Tests
-        env:
-          # run against the current Python interpreter
-          TOXENV: python
-        run: tox
+        run: tox -e py
       - uses: codecov/codecov-action@v3
         if: always()
         with:


### PR DESCRIPTION
Fix for the new tox 4.10.0 release (4.11.0 is now the newest):

```
Run tox
  tox
  shell: /usr/bin/bash -e {0}
  env:
    FORCE_COLOR: 1
    pythonLocation: /opt/hostedtoolcache/Python/3.10.12/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.12/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.12/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.12/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.12/x64/lib
    TOXENV: python
ROOT: HandledError| provided environments not found in configuration file:
python
Error: Process completed with exit code 254.
```

https://github.com/python/bedevere/actions/runs/6047954379/job/16412393623?pr=578

We use `pyXXX` in `tox.ini`:

```ini
envlist = py{312, 311, 310, 39, 38}
```

https://tox.wiki/en/latest/changelog.html#v4-10-0-2023-08-21 says:

> Change accepted environment name rule: must be made up of factors defined in configuration or match regex `(pypy|py|cython|)((\d(\.\d+(\.\d+)?)?)|\d+)?`. If an environment name does not match this fail, and if a close match found suggest that to the user. ([#3099](https://github.com/tox-dev/tox/issues/3099))
