### PR TITLE
Tweak the language for the help text

### DIFF
--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -29,10 +29,13 @@ SKIP_LABEL_STATUS = create_status(util.StatusState.SUCCESS,
 
 HELP = f"""\
 Most changes to Python [require a NEWS entry]\
-(https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python).
+(https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python). \
+You can add a NEWS entry using the [blurb_it]({BLURB_IT_URL}) web app or \
+the [blurb]({BLURB_PYPI_URL}) command-line tool.
 
-Please add it using the [blurb_it]({BLURB_IT_URL}) web app or the [blurb]\
-({BLURB_PYPI_URL}) command-line tool."""
+If this change has little impact on Python users, wait for a maintainer to confirm \
+that a NEWS entry is not required (they can apply the `skip news` label).
+"""
 
 
 async def check_news(gh, pull_request, files=None):

--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -30,11 +30,11 @@ SKIP_LABEL_STATUS = create_status(util.StatusState.SUCCESS,
 HELP = f"""\
 Most changes to Python [require a NEWS entry]\
 (https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python). \
-You can add a NEWS entry using the [blurb_it]({BLURB_IT_URL}) web app or \
+Add one using the [blurb_it]({BLURB_IT_URL}) web app or \
 the [blurb]({BLURB_PYPI_URL}) command-line tool.
 
-If this change has little impact on Python users, wait for a maintainer to confirm \
-that a NEWS entry is not required (they can apply the `skip news` label).
+If this change has little impact on Python users, wait for a maintainer to \
+apply the `skip news` label instead.
 """
 
 


### PR DESCRIPTION
The existing message did not cover the option of skipping the entry with `skip news`, which can result in unnecessary work being done by new contributors.

Resolves #590 