### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install tox
       - name: Run Tests
         run: tox -e py
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Reverts python/bedevere#623

This has a breaking change which affects us, requiring setting a token due to rate limiting:

* https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/ 
* https://github.com/codecov/feedback/issues/112#issuecomment-1919718118
* https://github.com/codecov/feedback/issues/112#issuecomment-1920204435

I think we could revert for now and see if they change track, otherwise we'll need to set a token first, and it would be better to do that at the org level.
