### PR TITLE
CI: Lint and test via uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,16 @@ name: Tests
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
 jobs:
   test:
     name: Python ${{ matrix.python-version }}
-
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
@@ -18,21 +19,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         id: python-install
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
+          allow-prereleases: true
+
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
+        with:
           cache-dependency-path: |
             requirements.txt
             dev-requirements.txt
-          allow-prereleases: true
-      - name: Install tox
+
+      - name: Tox tests
         run: |
-          python -m pip install tox
-      - name: Run Tests
-        run: tox -e py
+          uvx --with tox-uv tox -e py
+
       - uses: codecov/codecov-action@v4
         if: always()
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - uses: tox-dev/action-pre-commit-uv@v1


### PR DESCRIPTION
Like https://github.com/python/blurb/pull/32.

Tests:

* No cache: [2m 29s](https://github.com/hugovk/bedevere/actions/runs/11645308822/usage) -> [1m 57s](https://github.com/hugovk/bedevere/actions/runs/11645334667/usage)

* With cache: [2m 15s](https://github.com/hugovk/bedevere/actions/runs/11645345451/usage) -> [1m 58s](https://github.com/hugovk/bedevere/actions/runs/11645346035/usage)

Lint:

* We had a pre-commit config file but weren't running on the CI before. Let's add it.

Also:

* Fix https://github.com/woodruffw/zizmor findings (the `persist-credentials: false`).