### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{314, 313, 312, 311, 310, 39}
+envlist = py{314, 313, 312, 311, 310}
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]


### PR DESCRIPTION
This PR drops Python 3.9 support.

See also:
* #676
* https://github.com/python/blurb_it/pull/434