### PR TITLE
Support for Cabotage deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY bedevere bedevere
+
+CMD ["python", "-m", "bedevere"]

--- a/bedevere/__main__.py
+++ b/bedevere/__main__.py
@@ -78,20 +78,8 @@ if __name__ == "__main__":  # pragma: no cover
     app.router.add_post("/", main)
     app.router.add_get("/health", health_check)
 
-    socket_path = os.environ.get("SOCKET_PATH")
-    port = os.environ.get("PORT")
-
-    if socket_path:
-
-        async def run_with_socket():
-            runner = web.AppRunner(app)
-            await runner.setup()
-            site = web.UnixSite(runner, path=socket_path)
-            await site.start()
-            await asyncio.Event().wait()
-
-        asyncio.run(run_with_socket())
+    if os.path.isdir("/var/run/cabotage"):
+        web.run_app(app, path="/var/run/cabotage/cabotage.sock")
     else:
-        if port is not None:
-            port = int(port)
-        web.run_app(app, port=port)
+        port = os.environ.get("PORT")
+        web.run_app(app, port=int(port) if port else None)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -13,6 +13,15 @@ app_installation_payload = {
 }
 
 
+async def test_health_check(aiohttp_client):
+    app = web.Application()
+    app.router.add_get("/health", main.health_check)
+    client = await aiohttp_client(app)
+    response = await client.get("/health")
+    assert response.status == 200
+    assert await response.text() == "OK"
+
+
 async def test_ping(aiohttp_client):
     app = web.Application()
     app.router.add_post("/", main.main)


### PR DESCRIPTION
Initial support for migrating from Heroku (paid) to Cabotage (free)

Needs these set it cabo ui

- GH_SECRET
- GH_APP_ID
- GH_PRIVATE_KE
- SENTRY_DSN

Will require disabling Heroku deploy -> enabling cabotage
it is ready @ https://cabotage.us-east-2.psfhosted.computer/projects/python/bedevere/applications/bedevere 