### PR TITLE
Update link to "skip issue" label guidance

### DIFF
--- a/bedevere/gh_issue.py
+++ b/bedevere/gh_issue.py
@@ -130,7 +130,9 @@ def create_failure_status_issue_not_present(
 def create_failure_status_no_issue():
     """Create a failure status for when no issue number was found in the title."""
     description = 'No issue # in title or "skip issue" label found'
-    url = "https://devguide.python.org/getting-started/pull-request-lifecycle.html#submitting"
+    url = (
+        "https://devguide.python.org/getting-started/pull-request-lifecycle/#submitting"
+    )
     return util.create_status(
         STATUS_CONTEXT,
         util.StatusState.FAILURE,


### PR DESCRIPTION
Minor change, the old https://devguide.python.org/getting-started/pull-request-lifecycle.html#submitting redirects correctly to the new https://devguide.python.org/getting-started/pull-request-lifecycle/#submitting