### PR TITLE
Fix link to adding NEWS entry

### DIFF
--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -32,7 +32,7 @@ SKIP_LABEL_STATUS = create_status(
 
 HELP = f"""\
 Most changes to Python [require a NEWS entry]\
-(https://devguide.python.org/core-developers/committing/#updating-news-and-what-s-new-in-python). \
+(https://devguide.python.org/getting-started/pull-request-lifecycle/#news-entry). \
 Add one using the [blurb_it]({BLURB_IT_URL}) web app or \
 the [blurb]({BLURB_PYPI_URL}) command-line tool.
 


### PR DESCRIPTION
Follow on from https://github.com/python/devguide/pull/1819 which moved this content.

See also https://github.com/python/devguide/pull/1856.